### PR TITLE
Fix crash if info dictionary is NSNull

### DIFF
--- a/InstagramKit/Models/InstagramPaginationInfo.m
+++ b/InstagramKit/Models/InstagramPaginationInfo.m
@@ -18,9 +18,8 @@
 - (id)initWithInfo:(NSDictionary *)info andObjectType:(Class)type
 {
     self = [super init];
-    BOOL infoExists = IKNotNull(info);
-    BOOL nextURLExists = IKNotNull(info[kNextURL]);
-    if (self && infoExists && nextURLExists){
+    BOOL infoExists = IKNotNull(info) && IKNotNull(info[kNextURL]);
+    if (self && infoExists){
         
         _nextURL = [[NSURL alloc] initWithString:info[kNextURL]];
         BOOL nextMaxIdExists = IKNotNull(info[kNextMaxId]);


### PR DESCRIPTION
If the info dictionary passed to the initialiser is NSNull then the dictionary lookup for the key kNextURL will cause a crash, as the method for it is undefined on NSNull. Doing the checks using the logical and will only perform the lookup if there actually is a proper dictionary passed.
