### PR TITLE
Add id property needed to Instagram api query

### DIFF
--- a/InstagramKit/Models/InstagramModel.h
+++ b/InstagramKit/Models/InstagramModel.h
@@ -61,6 +61,7 @@
 #define kCreator @"from"
 #define kText @"text"
 
+#define kUserId @"id"
 #define kUsername @"username"
 #define kFullName @"full_name"
 #define kFirstName @"first_name"

--- a/InstagramKit/Models/InstagramUser.h
+++ b/InstagramKit/Models/InstagramUser.h
@@ -24,6 +24,7 @@
 
 @interface InstagramUser : InstagramModel
 
+@property (readonly) NSInteger userId;
 @property (readonly) NSString* username;
 @property (readonly) NSString* fullName;
 @property (readonly) NSURL* profilePictureURL;

--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -31,6 +31,8 @@
 {
     self = [super initWithInfo:info];
     if (self && IKNotNull(info)) {
+
+        _userId = [info[kUserId]integerValue];
         _username = [[NSString alloc] initWithString:info[kUsername]];
         _fullName = [[NSString alloc] initWithString:info[kFullName]];
         _profilePictureURL = [[NSURL alloc] initWithString:info[kProfilePictureURL]];


### PR DESCRIPTION
- (void)getFollowersOfUser:(NSString *)userId
             withSuccess:(InstagramObjectsBlock)success
                 failure:(InstagramFailureBlock)failure;

Using this method, user id is added to the model because
