### PR TITLE
Fix crash when media link is null

### DIFF
--- a/InstagramKit/Models/InstagramMedia.m
+++ b/InstagramKit/Models/InstagramMedia.m
@@ -41,7 +41,9 @@
         
         _user = [[InstagramUser alloc] initWithInfo:info[kUser]];
         _createdDate = [[NSDate alloc] initWithTimeIntervalSince1970:[info[kCreatedDate] doubleValue]];
-        _link = [[NSString alloc] initWithString:info[kLink]];
+        if (IKNotNull(info[kLink])) {
+            _link = [[NSString alloc] initWithString:info[kLink]];
+        }
         _caption = [[InstagramComment alloc] initWithInfo:info[kCaption]];
         _likesCount = [(info[kLikes])[kCount] integerValue];
         mLikes = [[NSMutableArray alloc] init];


### PR DESCRIPTION
API response for media of a private user does not include a value for the link property but instead returns null in this property. Instagram made this change recently.