### PR TITLE
Add type validation and null checking to all model object init methods to prevent crashes

### DIFF
--- a/InstagramKit/Categories/NSDictionary+IKValidation.h
+++ b/InstagramKit/Categories/NSDictionary+IKValidation.h
@@ -1,0 +1,22 @@
+//
+//  NSDictionary+IKValidation.h
+//  InstagramKitDemo
+//
+//  Created by Charles Scalesse on 2/12/15.
+//  Copyright (c) 2015 Shyam Bhat. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDictionary (IKValidation)
+
+- (id)ik_objectOrNilForKey:(id)key;
+- (NSDictionary *)ik_dictionaryForKey:(id)key;
+- (NSArray *)ik_arrayForKey:(id)key;
+- (NSString *)ik_stringForKey:(id)key;
+- (NSNumber *)ik_numberForKey:(id)key;
+- (NSURL *)ik_urlForKey:(id)key;
+- (BOOL)ik_boolForKey:(id)key;
+- (NSDate *)ik_dateForKey:(id)key;
+
+@end

--- a/InstagramKit/Categories/NSDictionary+IKValidation.m
+++ b/InstagramKit/Categories/NSDictionary+IKValidation.m
@@ -1,0 +1,69 @@
+//
+//  NSDictionary+IKValidation.m
+//  InstagramKitDemo
+//
+//  Created by Charles Scalesse on 2/12/15.
+//  Copyright (c) 2015 Shyam Bhat. All rights reserved.
+//
+
+#import "NSDictionary+IKValidation.h"
+
+@implementation NSDictionary (IKValidation)
+
+- (id)ik_objectOrNilForKey:(id)key {
+    id object = [self objectForKey:key];
+    if (object == [NSNull null] || [object isEqual:@"<null>"]) {
+        return nil;
+    }
+    return object;
+}
+
+- (NSDictionary *)ik_dictionaryForKey:(id)key {
+    NSDictionary *dictionary = [self ik_objectOrNilForKey:key];
+    if ([dictionary isKindOfClass:[NSDictionary class]]) {
+        return dictionary;
+    }
+    return nil;
+}
+
+- (NSArray *)ik_arrayForKey:(id)key {
+    NSArray *array = [self ik_objectOrNilForKey:key];
+    if ([array isKindOfClass:[NSArray class]]) {
+        return array;
+    }
+    return nil;
+}
+
+- (NSString *)ik_stringForKey:(id)key {
+    NSString *string = [self ik_objectOrNilForKey:key];
+    if ([string isKindOfClass:[NSString class]]) {
+        return string;
+    }
+    return nil;
+}
+
+- (NSNumber *)ik_numberForKey:(id)key {
+    NSNumber *number = [self ik_objectOrNilForKey:key];
+    if ([number isKindOfClass:[NSNumber class]]) {
+        return number;
+    }
+    return nil;
+}
+
+- (NSURL *)ik_urlForKey:(id)key {
+    NSString *urlString = [self ik_stringForKey:key];
+    if (!urlString) return nil;
+    return [NSURL URLWithString:urlString];
+}
+
+- (BOOL)ik_boolForKey:(id)key {
+    return [[self ik_objectOrNilForKey:key] boolValue];
+}
+
+- (NSDate *)ik_dateForKey:(id)key {
+    NSString *numberString = [self ik_stringForKey:key];
+    if (!numberString) return nil;
+    return [NSDate dateWithTimeIntervalSince1970:[numberString doubleValue]];
+}
+
+@end

--- a/InstagramKit/Models/IKUserInPhoto.m
+++ b/InstagramKit/Models/IKUserInPhoto.m
@@ -19,7 +19,6 @@
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "IKUserInPhoto.h"
-#import "NSDictionary+IKValidation.h"
 
 @implementation IKUserInPhoto
 

--- a/InstagramKit/Models/IKUserInPhoto.m
+++ b/InstagramKit/Models/IKUserInPhoto.m
@@ -19,14 +19,14 @@
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "IKUserInPhoto.h"
-#define IKNotNull(obj) (obj && ![obj isEqual:[NSNull null]])
+#import "NSDictionary+IKValidation.h"
 
 @implementation IKUserInPhoto
 
 - (id)initWithInfo:(NSDictionary *)info
 {
     self = [super init];
-    if (self && IKNotNull(info)) {
+    if (self && [info isKindOfClass:[NSDictionary class]]) {
         
     }
     return self;

--- a/InstagramKit/Models/InstagramComment.m
+++ b/InstagramKit/Models/InstagramComment.m
@@ -20,16 +20,17 @@
 
 #import "InstagramComment.h"
 #import "InstagramUser.h"
+#import "NSDictionary+IKValidation.h"
 
 @implementation InstagramComment
 
 - (id)initWithInfo:(NSDictionary *)info
 {
     self = [super initWithInfo:info];
-    if (self && IKNotNull(info)) {
-        _user = [[InstagramUser alloc] initWithInfo:info[kCreator]];
-        _text = [[NSString alloc] initWithString:info[kText]];
-        _createdDate = [[NSDate alloc] initWithTimeIntervalSince1970:[info[kCreatedDate] doubleValue]];
+    if (self && [info isKindOfClass:[NSDictionary class]]) {
+        _user = [[InstagramUser alloc] initWithInfo:[info ik_dictionaryForKey:kCreator]];
+        _text = [info ik_stringForKey:kText];
+        _createdDate = [info ik_dateForKey:kCreatedDate];
     }
     return self;
 }

--- a/InstagramKit/Models/InstagramMedia.m
+++ b/InstagramKit/Models/InstagramMedia.m
@@ -21,6 +21,7 @@
 #import "InstagramMedia.h"
 #import "InstagramUser.h"
 #import "InstagramComment.h"
+#import "NSDictionary+IKValidation.h"
 
 
 @interface InstagramMedia ()
@@ -37,39 +38,43 @@
 - (id)initWithInfo:(NSDictionary *)info
 {
     self = [super initWithInfo:info];
-    if (self && IKNotNull(info)) {
+    if (self && [info isKindOfClass:[NSDictionary class]]) {
         
         _user = [[InstagramUser alloc] initWithInfo:info[kUser]];
-        _createdDate = [[NSDate alloc] initWithTimeIntervalSince1970:[info[kCreatedDate] doubleValue]];
-        _link = [[NSString alloc] initWithString:info[kLink]];
+        _createdDate = [info ik_dateForKey:kCreatedDate];
+        _link = [info ik_stringForKey:kLink];
         _caption = [[InstagramComment alloc] initWithInfo:info[kCaption]];
-        _likesCount = [(info[kLikes])[kCount] integerValue];
+        _likesCount = [[[info ik_dictionaryForKey:kLikes] ik_numberForKey:kCount] integerValue];
+        
         mLikes = [[NSMutableArray alloc] init];
-        for (NSDictionary *userInfo in (info[kLikes])[kData]) {
+        for (NSDictionary *userInfo in ([[info ik_dictionaryForKey:kLikes] ik_arrayForKey:kData])) {
             InstagramUser *user = [[InstagramUser alloc] initWithInfo:userInfo];
             [mLikes addObject:user];
         }
         
-        _commentCount = [(info[kComments])[kCount] integerValue];
+        _commentCount = [[[info ik_dictionaryForKey:kComments] ik_numberForKey:kCount] integerValue];
         mComments = [[NSMutableArray alloc] init];
-        for (NSDictionary *commentInfo in (info[kComments])[kData]) {
+        for (NSDictionary *commentInfo in ([[info ik_dictionaryForKey:kComments] ik_arrayForKey:kData])) {
             InstagramComment *comment = [[InstagramComment alloc] initWithInfo:commentInfo];
             [mComments addObject:comment];
         }
-        _tags = [[NSArray alloc] initWithArray:info[kTags]];
-        
-        if (IKNotNull(info[kLocation])) {
-            _location = CLLocationCoordinate2DMake([(info[kLocation])[kLatitude] doubleValue], [(info[kLocation])[kLongitude] doubleValue]);
+        if ([info ik_arrayForKey:kTags]) {
+            _tags = [[NSArray alloc] initWithArray:[info ik_arrayForKey:kTags]];
         }
         
-        _filter = info[kFilter];
+        NSDictionary *locationDictionary = [info ik_dictionaryForKey:kLocation];
+        if ([locationDictionary ik_numberForKey:kLatitude] && [locationDictionary ik_numberForKey:kLongitude]) {
+            _location = CLLocationCoordinate2DMake([[locationDictionary ik_numberForKey:kLatitude] doubleValue], [[locationDictionary ik_numberForKey:kLongitude] doubleValue]);
+        }
         
-        [self initializeImages:info[kImages]];
+        _filter = [info ik_stringForKey:kFilter];
         
-        NSString* mediaType = info[kType];
-        _isVideo = [mediaType isEqualToString:[NSString stringWithFormat:@"%@",kMediaTypeVideo]];
+        [self initializeImages:[info ik_dictionaryForKey:kImages]];
+        
+        NSString *mediaType = [info ik_stringForKey:kType];
+        _isVideo = [mediaType isEqualToString:[NSString stringWithFormat:@"%@", kMediaTypeVideo]];
         if (_isVideo) {
-            [self initializeVideos:info[kVideos]];
+            [self initializeVideos:[info ik_dictionaryForKey:kVideos]];
         }
     }
     return self;
@@ -77,28 +82,38 @@
 
 - (void)initializeImages:(NSDictionary *)imagesInfo
 {
-    NSDictionary *thumbInfo = imagesInfo[kThumbnail];
-    _thumbnailURL = [[NSURL alloc] initWithString:thumbInfo[kURL]];
-    _thumbnailFrameSize = CGSizeMake([thumbInfo[kWidth] floatValue], [thumbInfo[kHeight] floatValue]);
+    NSDictionary *thumbInfo = [imagesInfo ik_dictionaryForKey:kThumbnail];
+    _thumbnailURL = [thumbInfo ik_urlForKey:kURL];
+    if ([thumbInfo ik_numberForKey:kWidth] && [thumbInfo ik_numberForKey:kHeight]) {
+        _thumbnailFrameSize = CGSizeMake([[thumbInfo ik_numberForKey:kWidth] floatValue], [[thumbInfo ik_numberForKey:kHeight] floatValue]);
+    }
     
-    NSDictionary *lowResInfo = imagesInfo[kLowResolution];
-    _lowResolutionImageURL = [[NSURL alloc] initWithString:lowResInfo[kURL]];
-    _lowResolutionImageFrameSize = CGSizeMake([lowResInfo[kWidth] floatValue], [lowResInfo[kHeight] floatValue]);
+    NSDictionary *lowResInfo = [imagesInfo ik_dictionaryForKey:kLowResolution];
+    _lowResolutionImageURL = [lowResInfo ik_urlForKey:kURL];
+    if ([lowResInfo ik_numberForKey:kWidth] && [lowResInfo ik_numberForKey:kHeight]) {
+        _lowResolutionImageFrameSize = CGSizeMake([[lowResInfo ik_numberForKey:kWidth] floatValue], [[lowResInfo ik_numberForKey:kHeight] floatValue]);
+    }
     
-    NSDictionary *standardResInfo = imagesInfo[kStandardResolution];
-    _standardResolutionImageURL = [[NSURL alloc] initWithString:standardResInfo[kURL]];
-    _standardResolutionImageFrameSize = CGSizeMake([standardResInfo[kWidth] floatValue], [standardResInfo[kHeight] floatValue]);
+    NSDictionary *standardResInfo = [imagesInfo ik_dictionaryForKey:kStandardResolution];
+    _standardResolutionImageURL = [standardResInfo ik_urlForKey:kURL];
+    if ([standardResInfo ik_numberForKey:kWidth] && [standardResInfo ik_numberForKey:kHeight]) {
+        _standardResolutionImageFrameSize = CGSizeMake([[standardResInfo ik_numberForKey:kWidth] floatValue], [[standardResInfo ik_numberForKey:kHeight] floatValue]);
+    }
 }
 
 - (void)initializeVideos:(NSDictionary *)videosInfo
 {
-    NSDictionary *lowResInfo = videosInfo[kLowResolution];
-    _lowResolutionVideoURL = [[NSURL alloc] initWithString:lowResInfo[kURL]];
-    _lowResolutionVideoFrameSize = CGSizeMake([lowResInfo[kWidth] floatValue], [lowResInfo[kHeight] floatValue]);
+    NSDictionary *lowResInfo = [videosInfo ik_dictionaryForKey:kLowResolution];
+    _lowResolutionVideoURL = [lowResInfo ik_urlForKey:kURL];
+    if ([lowResInfo ik_numberForKey:kWidth] && [lowResInfo ik_numberForKey:kHeight]) {
+        _lowResolutionVideoFrameSize = CGSizeMake([[lowResInfo ik_numberForKey:kWidth] floatValue], [[lowResInfo ik_numberForKey:kHeight] floatValue]);
+    }
     
-    NSDictionary *standardResInfo = videosInfo[kStandardResolution];
-    _standardResolutionVideoURL = [[NSURL alloc] initWithString:standardResInfo[kURL]];
-    _standardResolutionVideoFrameSize = CGSizeMake([standardResInfo[kWidth] floatValue], [standardResInfo[kHeight] floatValue]);
+    NSDictionary *standardResInfo = [videosInfo ik_dictionaryForKey:kStandardResolution];
+    _standardResolutionVideoURL = [standardResInfo ik_urlForKey:kURL];
+    if ([standardResInfo ik_numberForKey:kWidth] && [standardResInfo ik_numberForKey:kHeight]) {
+        _standardResolutionVideoFrameSize = CGSizeMake([[standardResInfo ik_numberForKey:kWidth] floatValue], [[standardResInfo ik_numberForKey:kHeight] floatValue]);
+    }
 }
 
 @end

--- a/InstagramKit/Models/InstagramMedia.m
+++ b/InstagramKit/Models/InstagramMedia.m
@@ -40,10 +40,10 @@
     self = [super initWithInfo:info];
     if (self && [info isKindOfClass:[NSDictionary class]]) {
         
-        _user = [[InstagramUser alloc] initWithInfo:info[kUser]];
+        _user = [[InstagramUser alloc] initWithInfo:[info ik_dictionaryForKey:kUser]];
         _createdDate = [info ik_dateForKey:kCreatedDate];
         _link = [info ik_stringForKey:kLink];
-        _caption = [[InstagramComment alloc] initWithInfo:info[kCaption]];
+        _caption = [[InstagramComment alloc] initWithInfo:[info ik_dictionaryForKey:kCaption]];
         _likesCount = [[[info ik_dictionaryForKey:kLikes] ik_numberForKey:kCount] integerValue];
         
         mLikes = [[NSMutableArray alloc] init];

--- a/InstagramKit/Models/InstagramModel.m
+++ b/InstagramKit/Models/InstagramModel.m
@@ -19,14 +19,15 @@
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "InstagramModel.h"
+#import "NSDictionary+IKValidation.h"
 
 @implementation InstagramModel
 
 - (id)initWithInfo:(NSDictionary *)info
 {
     self = [super init];
-    if (self && IKNotNull(info)) {
-        _Id = [[NSString alloc] initWithString:info[kID]];
+    if (self && [info isKindOfClass:[NSDictionary class]]) {
+        _Id = [info ik_stringForKey:kID];
     }
     return self;
 }

--- a/InstagramKit/Models/InstagramPaginationInfo.m
+++ b/InstagramKit/Models/InstagramPaginationInfo.m
@@ -8,6 +8,7 @@
 
 #import "InstagramPaginationInfo.h"
 #import "InstagramModel.h"
+#import "NSDictionary+IKValidation.h"
 
 @interface InstagramPaginationInfo ()
 @property (nonatomic, strong) Class type;
@@ -18,19 +19,13 @@
 - (id)initWithInfo:(NSDictionary *)info andObjectType:(Class)type
 {
     self = [super init];
-    BOOL infoExists = IKNotNull(info) && IKNotNull(info[kNextURL]);
-    if (self && infoExists){
+    BOOL infoExists = [info isKindOfClass:[NSDictionary class]] && [info ik_urlForKey:kNextURL];
+    if (self && infoExists) {
         
-        _nextURL = [[NSURL alloc] initWithString:info[kNextURL]];
-        BOOL nextMaxIdExists = IKNotNull(info[kNextMaxId]);
-        BOOL nextMaxLikeIdExists = IKNotNull(info[kNextMaxLikeId]);
-        if (nextMaxIdExists)
-        {
-            _nextMaxId = [[NSString alloc] initWithString:info[kNextMaxId]];
-        }
-        else if (nextMaxLikeIdExists)
-        {
-            _nextMaxId = [[NSString alloc] initWithString:info[kNextMaxLikeId]];
+        _nextURL = [info ik_urlForKey:kNextURL];
+        _nextMaxId = [info ik_stringForKey:kNextMaxId];
+        if (!_nextMaxId) {
+            _nextMaxId = [info ik_stringForKey:kNextMaxLikeId];
         }
         
         if (type) {

--- a/InstagramKit/Models/InstagramTag.m
+++ b/InstagramKit/Models/InstagramTag.m
@@ -21,15 +21,16 @@
 
 #import "InstagramTag.h"
 #import "InstagramModel.h"
+#import "NSDictionary+IKValidation.h"
 
 @implementation InstagramTag
 
 - (id)initWithInfo:(NSDictionary *)info
 {
     self = [super init];
-    if (self && IKNotNull(info)) {
-        _name = [[NSString alloc] initWithString:info[kTagName]];
-        _mediaCount = [info[kTagMediaCount] integerValue];
+    if (self && [info isKindOfClass:[NSDictionary class]]) {
+        _name = [info ik_stringForKey:kTagName];
+        _mediaCount = [[info ik_numberForKey:kTagMediaCount] integerValue];
     }
     return self;
 }

--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -20,6 +20,7 @@
 
 #import "InstagramUser.h"
 #import "InstagramEngine.h"
+#import "NSDictionary+IKValidation.h"
 
 @interface InstagramUser()
 @property (nonatomic, strong) NSArray *recentMedia;
@@ -30,22 +31,18 @@
 - (id)initWithInfo:(NSDictionary *)info
 {
     self = [super initWithInfo:info];
-    if (self && IKNotNull(info)) {
-        _username = [[NSString alloc] initWithString:info[kUsername]];
-        _fullName = [[NSString alloc] initWithString:info[kFullName]];
-        _profilePictureURL = [[NSURL alloc] initWithString:info[kProfilePictureURL]];
-        if (IKNotNull(info[kBio]))
-            _bio = [[NSString alloc] initWithString:info[kBio]];;
-        if (IKNotNull(info[kWebsite]))
-            _website = [[NSURL alloc] initWithString:info[kWebsite]];
+    if (self && [info isKindOfClass:[NSDictionary class]]) {
+        _username = [info ik_stringForKey:kUsername];
+        _fullName = [info ik_stringForKey:kFullName];
+        _profilePictureURL = [info ik_urlForKey:kProfilePictureURL];
+        _bio = [info ik_stringForKey:kBio];
+        _website = [info ik_urlForKey:kWebsite];
 
         // DO NOT PERSIST
-        if (IKNotNull(info[kCounts]))
-        {
-            _mediaCount = [(info[kCounts])[kCountMedia] integerValue];
-            _followsCount = [(info[kCounts])[kCountFollows] integerValue];
-            _followedByCount = [(info[kCounts])[kCountFollowedBy] integerValue];
-        }
+        NSDictionary *countsDictionary = [info ik_dictionaryForKey:kCounts];
+        _mediaCount = [[countsDictionary ik_numberForKey:kCountMedia] integerValue];
+        _followsCount = [[countsDictionary ik_numberForKey:kCountFollows] integerValue];
+        _followedByCount = [[countsDictionary ik_numberForKey:kCountFollowedBy] integerValue];
     }
     return self;
 }

--- a/InstagramKitDemo/InstagramKitDemo.xcodeproj/project.pbxproj
+++ b/InstagramKitDemo/InstagramKitDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		151536091A8D2120006EF175 /* NSDictionary+IKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 151536081A8D2120006EF175 /* NSDictionary+IKValidation.m */; };
 		52781D3C17CD6BB9001A32F7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781D3B17CD6BB9001A32F7 /* Foundation.framework */; };
 		52781D3E17CD6BB9001A32F7 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781D3D17CD6BB9001A32F7 /* CoreGraphics.framework */; };
 		52781D4017CD6BB9001A32F7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781D3F17CD6BB9001A32F7 /* UIKit.framework */; };
@@ -60,6 +61,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		151536071A8D2120006EF175 /* NSDictionary+IKValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+IKValidation.h"; sourceTree = "<group>"; };
+		151536081A8D2120006EF175 /* NSDictionary+IKValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+IKValidation.m"; sourceTree = "<group>"; };
 		52781D3817CD6BB9001A32F7 /* InstagramKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InstagramKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52781D3B17CD6BB9001A32F7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		52781D3D17CD6BB9001A32F7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -157,6 +160,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		151536061A8D2120006EF175 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				151536071A8D2120006EF175 /* NSDictionary+IKValidation.h */,
+				151536081A8D2120006EF175 /* NSDictionary+IKValidation.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
 		52781D2F17CD6BB9001A32F7 = {
 			isa = PBXGroup;
 			children = (
@@ -272,6 +284,7 @@
 			children = (
 				52781DA717CD6E64001A32F7 /* InstagramKit.h */,
 				820D6DC118B7DC6900847053 /* InstagramKit.plist */,
+				151536061A8D2120006EF175 /* Categories */,
 				52781DA417CD6E64001A32F7 /* Engine */,
 				52781DA817CD6E64001A32F7 /* Models */,
 			);
@@ -439,6 +452,7 @@
 				825BB4C518A183D800F3BDF3 /* AFURLSessionManager.m in Sources */,
 				825BB4C818A1849600F3BDF3 /* UIImageView+AFNetworking.m in Sources */,
 				825BB4C218A183D800F3BDF3 /* AFURLConnectionOperation.m in Sources */,
+				151536091A8D2120006EF175 /* NSDictionary+IKValidation.m in Sources */,
 				82AC29F3189D27C000675776 /* InstagramTag.m in Sources */,
 				825BB4BF18A183D800F3BDF3 /* AFHTTPSessionManager.m in Sources */,
 				825BB4C018A183D800F3BDF3 /* AFNetworkReachabilityManager.m in Sources */,


### PR DESCRIPTION
Hey @shyambhat, thanks for creating this library. Our production app recently experienced a spike in crashes (as noted in issue #90) due to improper null-checking. After investigating, I noticed two serious issues:

1. Inconsistent checking for `NSNull` when creating model objects
2. No type checking when dealing with objects pulled from `NSDictionary`

As a result, if Instagram changes their API or is experiencing any technical issues (eg: sending back `null` for a property that isn't expecting `null`), any applications using `InstagramKit` will crash. This pull request does the following:

**1. Removes dependence on the `IKNotNull` macro during model object creation.
2. Implements a new `NSDictionary+IKValidation` category that null-checks every value returned from the Instagram API and also checks that the type of each object is of the expected type**

Now, if the InstagramAPI changes and/or experiences bugs, applications using `InstagramKit` won't crash.

Let me know if you have questions. Thanks!