### PR TITLE
Added cursor instead of max_id into Relationships PaginationInfo

### DIFF
--- a/InstagramKit/Models/InstagramModel.h
+++ b/InstagramKit/Models/InstagramModel.h
@@ -81,9 +81,11 @@
 #define kNextMaxId @"next_max_id"
 #define kNextMaxLikeId @"next_max_like_id"
 #define kNextMaxTagId @"next_max_tag_id"
+#define kNextCursor @"next_cursor"
 
 #define kMaxId @"max_id"
 #define kMaxLikeId @"max_like_id"
 #define kMaxTagId @"max_tag_id"
+#define kCursor @"cursor"
 
 #define IKNotNull(obj) (obj && (![obj isEqual:[NSNull null]]) && (![obj isEqual:@"<null>"]) )

--- a/InstagramKit/Models/InstagramPaginationInfo.h
+++ b/InstagramKit/Models/InstagramPaginationInfo.h
@@ -11,8 +11,12 @@
 @interface InstagramPaginationInfo : NSObject
 
 @property (readonly) NSURL* nextURL;
-@property (readonly) NSString *nextMaxId;
+@property (readonly) NSString* nextIdType;
 @property (readonly) Class type;
+
+-(NSString *)nextMaxId;
+-(NSString *)nextCursor;
+
 - (id)initWithInfo:(NSDictionary *)info andObjectType:(Class)type;
 
 @end

--- a/InstagramKit/Models/InstagramPaginationInfo.m
+++ b/InstagramKit/Models/InstagramPaginationInfo.m
@@ -11,6 +11,7 @@
 
 @interface InstagramPaginationInfo ()
 @property (nonatomic, strong) Class type;
+@property (readonly) NSString* nextId;
 @end
 
 @implementation InstagramPaginationInfo
@@ -24,13 +25,21 @@
         _nextURL = [[NSURL alloc] initWithString:info[kNextURL]];
         BOOL nextMaxIdExists = IKNotNull(info[kNextMaxId]);
         BOOL nextMaxLikeIdExists = IKNotNull(info[kNextMaxLikeId]);
+        BOOL nextCursorExists = IKNotNull(info[kNextCursor]);
         if (nextMaxIdExists)
         {
-            _nextMaxId = [[NSString alloc] initWithString:info[kNextMaxId]];
+            _nextId = [[NSString alloc] initWithString:info[kNextMaxId]];
+            _nextIdType = kMaxId;
         }
         else if (nextMaxLikeIdExists)
         {
-            _nextMaxId = [[NSString alloc] initWithString:info[kNextMaxLikeId]];
+            _nextId = [[NSString alloc] initWithString:info[kNextMaxLikeId]];
+            _nextIdType = kMaxId;
+        }
+        else if (nextCursorExists)
+        {
+            _nextId = [[NSString alloc] initWithString:info[kNextCursor]];
+            _nextIdType = kCursor;
         }
         
         if (type) {
@@ -40,5 +49,19 @@
     }
     return nil;
 }
+
+-(NSString *)nextMaxId
+{
+    if([_nextIdType isEqual:kMaxId])
+        return _nextId;
+    return nil;
+}
+-(NSString *)nextCursor
+{
+    if([_nextIdType isEqual:kCursor])
+        return _nextId;
+    return nil;
+}
+
 
 @end


### PR DESCRIPTION
The Instagram relationship API's does not support next_max_id in the pagination object. Instead it supports next_cursor. The next feature IMHO would be to implement pagination in the relationship convenience methods using counts and cursor.