### PR TITLE
Model equality

### DIFF
--- a/InstagramKit/Models/InstagramComment.h
+++ b/InstagramKit/Models/InstagramComment.h
@@ -29,4 +29,6 @@
 @property (nonatomic, strong) InstagramUser *user;
 @property (nonatomic, strong) NSString *text;
 
+- (BOOL) isEqualToInstagramComment: (InstagramComment *) comment;
+
 @end

--- a/InstagramKit/Models/InstagramComment.m
+++ b/InstagramKit/Models/InstagramComment.m
@@ -34,5 +34,29 @@
     return self;
 }
 
+- (BOOL) isEqualToInstagramComment: (InstagramComment *) comment {
+
+    if (!comment) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: comment];
+
+} // -isEqualToInstagramComment:
+
+
+- (BOOL) isEqual: (id) object {
+
+    if (self == object) {
+
+        return YES;
+    }
+    if (![object isKindOfClass: [InstagramComment class]]) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: (InstagramComment *) object];
+    
+} // -isEqual:
 
 @end

--- a/InstagramKit/Models/InstagramMedia.h
+++ b/InstagramKit/Models/InstagramMedia.h
@@ -55,4 +55,6 @@
 @property (nonatomic, readonly) NSURL *standardResolutionVideoURL;
 @property (nonatomic, readonly) CGSize standardResolutionVideoFrameSize;
 
+- (BOOL) isEqualToInstagramMedia: (InstagramMedia *) media;
+
 @end

--- a/InstagramKit/Models/InstagramMedia.m
+++ b/InstagramKit/Models/InstagramMedia.m
@@ -102,4 +102,29 @@
     _standardResolutionVideoFrameSize = CGSizeMake([standardResInfo[kWidth] floatValue], [standardResInfo[kHeight] floatValue]);
 }
 
+- (BOOL) isEqualToInstagramMedia: (InstagramMedia *) media {
+
+    if (!media) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: media];
+
+} // -isEqualToInstagramMedia:
+
+
+- (BOOL) isEqual: (id) object {
+
+    if (self == object) {
+
+        return YES;
+    }
+    if (![object isKindOfClass: [InstagramMedia class]]) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: (InstagramModel *) object];
+    
+} // -isEqual:
+
 @end

--- a/InstagramKit/Models/InstagramModel.h
+++ b/InstagramKit/Models/InstagramModel.h
@@ -24,7 +24,9 @@
 
 @property (readonly) NSString* Id;
 
-- (id)initWithInfo:(NSDictionary *)info;
+- (instancetype)initWithInfo:(NSDictionary *)info NS_DESIGNATED_INITIALIZER;
+
+- (BOOL) isEqualToInstagramModel: (InstagramModel *) model;
 
 @end
 

--- a/InstagramKit/Models/InstagramModel.m
+++ b/InstagramKit/Models/InstagramModel.m
@@ -20,9 +20,15 @@
 
 #import "InstagramModel.h"
 
+@interface InstagramModel ()
+
+@property (readonly) NSUInteger hash;
+
+@end
+
 @implementation InstagramModel
 
-- (id)initWithInfo:(NSDictionary *)info
+- (instancetype)initWithInfo:(NSDictionary *)info
 {
     self = [super init];
     if (self && IKNotNull(info)) {
@@ -30,5 +36,39 @@
     }
     return self;
 }
+
+@dynamic hash;
+
+- (NSUInteger) hash {
+
+    return self.Id.hash;
+
+} // -hash
+
+
+- (BOOL) isEqualToInstagramModel: (InstagramModel *) model {
+
+    if (!model) {
+
+        return NO;
+    }
+    return [self.Id isEqualToString: model.Id];
+
+} // -isEqualToInstagramModel:
+
+
+- (BOOL) isEqual: (id) object {
+
+    if (self == object) {
+
+        return YES;
+    }
+    if (![object isKindOfClass: [InstagramModel class]]) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: (InstagramModel *) object];
+    
+} // -isEqual:
 
 @end

--- a/InstagramKit/Models/InstagramUser.h
+++ b/InstagramKit/Models/InstagramUser.h
@@ -42,4 +42,6 @@
 - (void)loadRecentMedia:(NSInteger)count;
 - (void)loadRecentMedia:(NSInteger)count withSuccess:(void(^)(void))success failure:(void(^)(void))failure;
 
+- (BOOL) isEqualToInstagramUser: (InstagramUser *) user;
+
 @end

--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -82,4 +82,29 @@
     }];
 }
 
+- (BOOL) isEqualToInstagramUser: (InstagramUser *) user {
+
+    if (!user) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: user];
+
+} // -isEqualToInstagramUser:
+
+
+- (BOOL) isEqual: (id) object {
+
+    if (self == object) {
+
+        return YES;
+    }
+    if (![object isKindOfClass: [InstagramUser class]]) {
+
+        return NO;
+    }
+    return [self isEqualToInstagramModel: (InstagramUser *) object];
+    
+} // -isEqual:
+
 @end


### PR DESCRIPTION
I use collection classes that test for uniqueness (NSSet, etc.). Instagram provides a unique identifier in the form of the "id". As the InstagramModel class is the repository for "Id", it is the natural place to create a unique identifier for model items. I use the Id string for equality testing and its -hash to create the -hash for model derived classes.