### PR TITLE
Added locationName property & removed readonly for userHasLiked for InstagramMedia.

### DIFF
--- a/InstagramKit/Models/InstagramMedia.h
+++ b/InstagramKit/Models/InstagramMedia.h
@@ -39,8 +39,9 @@
 @property (nonatomic, readonly) NSArray *comments;
 @property (nonatomic, readonly) NSArray *tags;
 @property (nonatomic, readonly) CLLocationCoordinate2D location;
-@property (nonatomic, readonly) NSString* filter;
-@property (nonatomic, readonly) NSDictionary* images;
+@property (nonatomic, readonly) NSString *locationName;
+@property (nonatomic, readonly) NSString *filter;
+@property (nonatomic, readonly) NSDictionary *images;
 
 @property (nonatomic, readonly) NSURL *thumbnailURL;
 @property (nonatomic, readonly) CGSize thumbnailFrameSize;

--- a/InstagramKit/Models/InstagramMedia.h
+++ b/InstagramKit/Models/InstagramMedia.h
@@ -29,7 +29,7 @@
 @interface InstagramMedia : InstagramModel
 
 @property (nonatomic, readonly) InstagramUser* user;
-@property (nonatomic, readonly) BOOL userHasLiked;
+@property (nonatomic) BOOL userHasLiked;
 @property (nonatomic, readonly) NSDate *createdDate;
 @property (nonatomic, readonly) NSString* link;
 @property (nonatomic, readonly) InstagramComment* caption;

--- a/InstagramKit/Models/InstagramMedia.m
+++ b/InstagramKit/Models/InstagramMedia.m
@@ -61,6 +61,7 @@
         
         if (IKNotNull(info[kLocation])) {
             _location = CLLocationCoordinate2DMake([(info[kLocation])[kLatitude] doubleValue], [(info[kLocation])[kLongitude] doubleValue]);
+            _locationName = info[kLocation][kLocationName];
         }
         
         _filter = info[kFilter];

--- a/InstagramKit/Models/InstagramModel.h
+++ b/InstagramKit/Models/InstagramModel.h
@@ -37,6 +37,7 @@
 #define kData @"data"
 #define kLatitude @"latitude"
 #define kLongitude @"longitude"
+#define kLocationName @"name"
 
 #define kThumbnail @"thumbnail"
 #define kLowResolution @"low_resolution"


### PR DESCRIPTION
Added a locationName property for the InstagramMedia object for displaying of location name. Tested and working fine for media with and without location data.

I've also removed readonly for the userHasLiked property as it needs to be updated immediately when the user has liked/disliked the current media *(e.g. when userHasLiked is NO and the user just liked the photo, the property needs to be set to YES so that the next time the user taps a "like button" again, the unlike code can be executed)*.