### PR TITLE
Expose server response

### DIFF
--- a/InstagramKit/Engine/InstagramEngine.h
+++ b/InstagramKit/Engine/InstagramEngine.h
@@ -29,11 +29,12 @@
 
 
 typedef void(^InstagramLoginBlock)(NSError* error);
-typedef void(^InstagramMediaBlock)(NSArray *media, InstagramPaginationInfo *paginationInfo);
-typedef void (^InstagramObjectsBlock)(NSArray *objects, InstagramPaginationInfo *paginationInfo);
-typedef void (^InstagramTagsBlock)(NSArray *tags, InstagramPaginationInfo *paginationInfo);
-typedef void (^InstagramCommentsBlock)(NSArray *comments);
-typedef void (^InstagramFailureBlock)(NSError* error);
+typedef void(^InstagramSelfUserBlock)(InstagramUser *userDetail, NSDictionary *serverResponse);
+typedef void(^InstagramMediaBlock)(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
+typedef void (^InstagramObjectsBlock)(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
+typedef void (^InstagramTagsBlock)(NSArray *tags, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
+typedef void (^InstagramCommentsBlock)(NSArray *comments, NSDictionary *serverResponse);
+typedef void (^InstagramFailureBlock)(NSError* error, NSInteger serverStatusCode);
 
 extern NSString *const kInstagramKitAppClientIdConfigurationKey;
 extern NSString *const kInstagramKitAppRedirectUrlConfigurationKey;
@@ -110,7 +111,7 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getMedia:(NSString *)mediaId
-     withSuccess:(void (^)(InstagramMedia *media))success
+     withSuccess:(void (^)(InstagramMedia *media, NSDictionary *serverResponse))success
          failure:(InstagramFailureBlock)failure;
 
 
@@ -134,7 +135,7 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getUserDetails:(NSString *)userId
-           withSuccess:(void (^)(InstagramUser *userDetail))success
+           withSuccess:(void (^)(InstagramUser *userDetail, NSDictionary *serverResponse))success
                failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
@@ -152,7 +153,7 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)searchUsersWithString:(NSString *)string
-                  withSuccess:(void (^)(NSArray *users, InstagramPaginationInfo *paginationInfo))success
+                  withSuccess:(void (^)(NSArray *users, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
                       failure:(InstagramFailureBlock)failure;
 
 
@@ -160,7 +161,7 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 #pragma mark - Self User -
 
 
-- (void)getSelfUserDetailsWithSuccess:(void (^)(InstagramUser *userDetail))success
+- (void)getSelfUserDetailsWithSuccess:(InstagramSelfUserBlock)success
                               failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
@@ -198,7 +199,7 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getTagDetailsWithName:(NSString *)name
-                  withSuccess:(void (^)(InstagramTag *tag))success
+                  withSuccess:(void (^)(InstagramTag *tag, NSDictionary *serverResponse))success
                       failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
@@ -263,8 +264,8 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getRelationshipStatusOfUser:(NSString *)userId
-                          withSuccess:(void (^)(NSDictionary *responseDictionary))success
-                              failure:(void (^)(NSError* error))failure;
+                          withSuccess:(void (^)(NSDictionary *responseDictionary, NSDictionary *serverResponse))success
+                              failure:(InstagramFailureBlock)failure;
 
 - (void)getUsersFollowedByUser:(NSString *)userId
                    withSuccess:(InstagramObjectsBlock)success
@@ -279,33 +280,33 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 - (void)followUser:(NSString *)userId
        withSuccess:(void (^)(NSDictionary *response))success
-           failure:(void (^)(NSError* error))failure;
+           failure:(InstagramFailureBlock)failure;
 
 - (void)unfollowUser:(NSString *)userId
          withSuccess:(void (^)(NSDictionary *response))success
-             failure:(void (^)(NSError* error))failure;
+             failure:(InstagramFailureBlock)failure;
 
 - (void)blockUser:(NSString *)userId
        withSuccess:(void (^)(NSDictionary *response))success
-           failure:(void (^)(NSError* error))failure;
+           failure:(InstagramFailureBlock)failure;
 
 - (void)unblockUser:(NSString *)userId
          withSuccess:(void (^)(NSDictionary *response))success
-             failure:(void (^)(NSError* error))failure;
+             failure:(InstagramFailureBlock)failure;
 
 - (void)approveUser:(NSString *)userId
         withSuccess:(void (^)(NSDictionary *response))success
-            failure:(void (^)(NSError* error))failure;
+            failure:(InstagramFailureBlock)failure;
 
 - (void)denyUser:(NSString *)userId
         withSuccess:(void (^)(NSDictionary *response))success
-            failure:(void (^)(NSError* error))failure;
+            failure:(InstagramFailureBlock)failure;
 
 
 #pragma mark - Common Pagination Request -
 
 - (void)getPaginatedItemsForInfo:(InstagramPaginationInfo *)paginationInfo
-                     withSuccess:(void (^)(NSArray *objects, InstagramPaginationInfo *paginationInfo))success
+                     withSuccess:(void (^)(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
                          failure:(InstagramFailureBlock)failure;
 
 @end

--- a/InstagramKit/Engine/InstagramEngine.h
+++ b/InstagramKit/Engine/InstagramEngine.h
@@ -106,6 +106,7 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
             annotation:(id)annotation;
 
 - (void)logout;
+- (BOOL)isSessionValid;
 
 #pragma mark - Media -
 

--- a/InstagramKit/Engine/InstagramEngine.h
+++ b/InstagramKit/Engine/InstagramEngine.h
@@ -28,12 +28,16 @@
 @class InstagramTag;
 
 
-typedef void(^InstagramLoginBlock)(NSError* error);
-typedef void(^InstagramSelfUserBlock)(InstagramUser *userDetail, NSDictionary *serverResponse);
-typedef void(^InstagramMediaBlock)(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
+typedef void (^InstagramLoginBlock)(NSError *error);
+typedef void (^InstagramSelfUserBlock)(InstagramUser *userDetail, NSDictionary *serverResponse);
+typedef void (^InstagramMediaBlock)(InstagramMedia *media, NSDictionary *serverResponse);
+typedef void (^InstagramMediaListBlock)(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
 typedef void (^InstagramObjectsBlock)(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
 typedef void (^InstagramTagsBlock)(NSArray *tags, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
+typedef void (^InstagramTagBlock)(InstagramTag *tag, NSDictionary *serverResponse);
 typedef void (^InstagramCommentsBlock)(NSArray *comments, NSDictionary *serverResponse);
+typedef void (^InstagramUsersBlock)(NSArray *users, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse);
+typedef void (^InstagramGenericResponseBlock)(NSDictionary *serverResponse);
 typedef void (^InstagramFailureBlock)(NSError* error, NSInteger serverStatusCode);
 
 extern NSString *const kInstagramKitAppClientIdConfigurationKey;
@@ -65,17 +69,17 @@ typedef enum
     kInstagramKitErrorCodeNone,
     kInstagramKitErrorCodeAccessNotGranted,
     kInstagramKitErrorCodeUserCancelled = NSUserCancelledError,
-
+    
 } InstagramKitErrorCode;
 
 typedef NS_OPTIONS(NSInteger, IKLoginScope) {
-//    Default, to read any and all data related to a user (e.g. following/followed-by lists, photos, etc.)
+    //    Default, to read any and all data related to a user (e.g. following/followed-by lists, photos, etc.)
     IKLoginScopeBasic = 0,
-//    to create or delete comments on a user’s behalf
+    //    to create or delete comments on a user’s behalf
     IKLoginScopeComments = 1<<1,
-//    to follow and unfollow users on a user’s behalf
+    //    to follow and unfollow users on a user’s behalf
     IKLoginScopeRelationships = 1<<2,
-//    to like and unlike items on a user’s behalf
+    //    to like and unlike items on a user’s behalf
     IKLoginScopeLikes = 1<<3
 };
 
@@ -101,9 +105,9 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
-            sourceApplication:(NSString *)
-            sourceApplication
-            annotation:(id)annotation;
+  sourceApplication:(NSString *)
+sourceApplication
+         annotation:(id)annotation;
 
 - (void)logout;
 - (BOOL)isSessionValid;
@@ -112,22 +116,24 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getMedia:(NSString *)mediaId
-     withSuccess:(void (^)(InstagramMedia *media, NSDictionary *serverResponse))success
+     withSuccess:(InstagramMediaBlock)success
          failure:(InstagramFailureBlock)failure;
 
 
-- (void)getPopularMediaWithSuccess:(InstagramMediaBlock)success
+- (void)getPopularMediaWithSuccess:(InstagramMediaListBlock)success
                            failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
 
 
 - (void)getMediaAtLocation:(CLLocationCoordinate2D)location
-               withSuccess:(InstagramMediaBlock)success
+               withSuccess:(InstagramMediaListBlock)success
                    failure:(InstagramFailureBlock)failure;
 
-- (void)getMediaAtLocation:(CLLocationCoordinate2D)location count:(NSInteger)count maxId:(NSString *)maxId
-               withSuccess:(InstagramMediaBlock)success
+- (void)getMediaAtLocation:(CLLocationCoordinate2D)location
+                     count:(NSInteger)count
+                     maxId:(NSString *)maxId
+               withSuccess:(InstagramMediaListBlock)success
                    failure:(InstagramFailureBlock)failure;
 
 
@@ -136,25 +142,27 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getUserDetails:(NSString *)userId
-           withSuccess:(void (^)(InstagramUser *userDetail, NSDictionary *serverResponse))success
+           withSuccess:(InstagramSelfUserBlock)success
                failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
 
 
 - (void)getMediaForUser:(NSString *)userId
-        withSuccess:(InstagramMediaBlock)success
-            failure:(InstagramFailureBlock)failure;
+            withSuccess:(InstagramMediaListBlock)success
+                failure:(InstagramFailureBlock)failure;
 
-- (void)getMediaForUser:(NSString *)userId count:(NSInteger)count maxId:(NSString *)maxId
-            withSuccess:(InstagramMediaBlock)success
+- (void)getMediaForUser:(NSString *)userId
+                  count:(NSInteger)count
+                  maxId:(NSString *)maxId
+            withSuccess:(InstagramMediaListBlock)success
                 failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
 
 
 - (void)searchUsersWithString:(NSString *)string
-                  withSuccess:(void (^)(NSArray *users, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
+                  withSuccess:(InstagramUsersBlock)success
                       failure:(InstagramFailureBlock)failure;
 
 
@@ -168,50 +176,55 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 #pragma mark -
 
 
-- (void)getSelfFeedWithSuccess:(InstagramMediaBlock)success
-            failure:(InstagramFailureBlock)failure;
+- (void)getSelfFeedWithSuccess:(InstagramMediaListBlock)success
+                       failure:(InstagramFailureBlock)failure;
 
-- (void)getSelfFeedWithCount:(NSInteger)count maxId:(NSString *)maxId
-        success:(InstagramMediaBlock)success
-            failure:(InstagramFailureBlock)failure;
+- (void)getSelfFeedWithCount:(NSInteger)count
+                       maxId:(NSString *)maxId
+                     success:(InstagramMediaListBlock)success
+                     failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
 
 
-- (void)getMediaLikedBySelfWithSuccess:(InstagramMediaBlock)success
-                        failure:(InstagramFailureBlock)failure;
-
-- (void)getMediaLikedBySelfWithCount:(NSInteger)count maxId:(NSString *)maxId
-                             success:(InstagramMediaBlock)success
+- (void)getMediaLikedBySelfWithSuccess:(InstagramMediaListBlock)success
                                failure:(InstagramFailureBlock)failure;
 
+- (void)getMediaLikedBySelfWithCount:(NSInteger)count
+                               maxId:(NSString *)maxId
+                             success:(InstagramMediaListBlock)success
+                             failure:(InstagramFailureBlock)failure;
 
 
-#pragma mark - 
 
-- (void)getSelfRecentMediaWithSuccess:(InstagramMediaBlock)success
-							  failure:(InstagramFailureBlock)failure;
+#pragma mark -
 
-- (void)getSelfRecentMediaWithCount:(NSInteger)count maxId:(NSString *)maxId
-							  success:(InstagramMediaBlock)success
-							  failure:(InstagramFailureBlock)failure;
+- (void)getSelfRecentMediaWithSuccess:(InstagramMediaListBlock)success
+                              failure:(InstagramFailureBlock)failure;
+
+- (void)getSelfRecentMediaWithCount:(NSInteger)count
+                              maxId:(NSString *)maxId
+                            success:(InstagramMediaListBlock)success
+                            failure:(InstagramFailureBlock)failure;
 
 #pragma mark - Tags -
 
 
 - (void)getTagDetailsWithName:(NSString *)name
-                  withSuccess:(void (^)(InstagramTag *tag, NSDictionary *serverResponse))success
+                  withSuccess:(InstagramTagBlock)success
                       failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
 
 
 - (void)getMediaWithTagName:(NSString *)tag
-            withSuccess:(InstagramMediaBlock)success
-                failure:(InstagramFailureBlock)failure;
+                withSuccess:(InstagramMediaListBlock)success
+                    failure:(InstagramFailureBlock)failure;
 
-- (void)getMediaWithTagName:(NSString *)tag count:(NSInteger)count maxId:(NSString *)maxId
-                withSuccess:(InstagramMediaBlock)success
+- (void)getMediaWithTagName:(NSString *)tag
+                      count:(NSInteger)count
+                      maxId:(NSString *)maxId
+                withSuccess:(InstagramMediaListBlock)success
                     failure:(InstagramFailureBlock)failure;
 
 #pragma mark -
@@ -221,7 +234,9 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
                withSuccess:(InstagramTagsBlock)success
                    failure:(InstagramFailureBlock)failure;
 
-- (void)searchTagsWithName:(NSString *)name count:(NSInteger)count maxId:(NSString *)maxId
+- (void)searchTagsWithName:(NSString *)name
+                     count:(NSInteger)count
+                     maxId:(NSString *)maxId
                withSuccess:(InstagramTagsBlock)success
                    failure:(InstagramFailureBlock)failure;
 
@@ -236,12 +251,12 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 - (void)createComment:(NSString *)commentText
               onMedia:(NSString *)mediaId
-          withSuccess:(void (^)(void))success
+          withSuccess:(dispatch_block_t)success
               failure:(InstagramFailureBlock)failure;
 
 - (void)removeComment:(NSString *)commentId
               onMedia:(NSString *)mediaId
-          withSuccess:(void (^)(void))success
+          withSuccess:(dispatch_block_t)success
               failure:(InstagramFailureBlock)failure;
 
 
@@ -249,15 +264,15 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getLikesOnMedia:(NSString *)mediaId
-            withSuccess:(void (^)(NSArray *likedUsers))success
+            withSuccess:(InstagramObjectsBlock)success
                 failure:(InstagramFailureBlock)failure;
 
 - (void)likeMedia:(NSString *)mediaId
-      withSuccess:(void (^)(void))success
+      withSuccess:(dispatch_block_t)success
           failure:(InstagramFailureBlock)failure;
 
 - (void)unlikeMedia:(NSString *)mediaId
-        withSuccess:(void (^)(void))success
+        withSuccess:(dispatch_block_t)success
             failure:(InstagramFailureBlock)failure;
 
 
@@ -265,8 +280,8 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
 
 
 - (void)getRelationshipStatusOfUser:(NSString *)userId
-                          withSuccess:(void (^)(NSDictionary *responseDictionary, NSDictionary *serverResponse))success
-                              failure:(InstagramFailureBlock)failure;
+                        withSuccess:(InstagramGenericResponseBlock)success
+                            failure:(InstagramFailureBlock)failure;
 
 - (void)getUsersFollowedByUser:(NSString *)userId
                    withSuccess:(InstagramObjectsBlock)success
@@ -277,37 +292,37 @@ typedef NS_OPTIONS(NSInteger, IKLoginScope) {
                    failure:(InstagramFailureBlock)failure;
 
 - (void)getFollowRequestsWithSuccess:(InstagramObjectsBlock)success
-                        failure:(InstagramFailureBlock)failure;
+                             failure:(InstagramFailureBlock)failure;
 
 - (void)followUser:(NSString *)userId
-       withSuccess:(void (^)(NSDictionary *response))success
+       withSuccess:(InstagramGenericResponseBlock)success
            failure:(InstagramFailureBlock)failure;
 
 - (void)unfollowUser:(NSString *)userId
-         withSuccess:(void (^)(NSDictionary *response))success
+         withSuccess:(InstagramGenericResponseBlock)success
              failure:(InstagramFailureBlock)failure;
 
 - (void)blockUser:(NSString *)userId
-       withSuccess:(void (^)(NSDictionary *response))success
-           failure:(InstagramFailureBlock)failure;
+      withSuccess:(InstagramGenericResponseBlock)success
+          failure:(InstagramFailureBlock)failure;
 
 - (void)unblockUser:(NSString *)userId
-         withSuccess:(void (^)(NSDictionary *response))success
-             failure:(InstagramFailureBlock)failure;
+        withSuccess:(InstagramGenericResponseBlock)success
+            failure:(InstagramFailureBlock)failure;
 
 - (void)approveUser:(NSString *)userId
-        withSuccess:(void (^)(NSDictionary *response))success
+        withSuccess:(InstagramGenericResponseBlock)success
             failure:(InstagramFailureBlock)failure;
 
 - (void)denyUser:(NSString *)userId
-        withSuccess:(void (^)(NSDictionary *response))success
-            failure:(InstagramFailureBlock)failure;
+     withSuccess:(InstagramGenericResponseBlock)success
+         failure:(InstagramFailureBlock)failure;
 
 
 #pragma mark - Common Pagination Request -
 
 - (void)getPaginatedItemsForInfo:(InstagramPaginationInfo *)paginationInfo
-                     withSuccess:(void (^)(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
+                     withSuccess:(InstagramObjectsBlock)success
                          failure:(InstagramFailureBlock)failure;
 
 @end

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -304,7 +304,7 @@ typedef enum
 - (void)getPath:(NSString *)path
      parameters:(NSDictionary *)parameters
   responseModel:(Class)modelClass
-        success:(void (^)(id response, InstagramPaginationInfo *paginationInfo))success
+        success:(void (^)(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
         failure:(void (^)(NSError* error, NSInteger statusCode))failure
 {
 
@@ -342,7 +342,7 @@ typedef enum
                            }
                        }
                        dispatch_async(dispatch_get_main_queue(), ^{
-                           success(objects, paginationInfo);
+                           success(objects, paginationInfo, responseDictionary);
                        });
                    });
                }
@@ -358,7 +358,7 @@ typedef enum
                            model = [[modelClass alloc] initWithInfo:responseDictionary[kData]];
                        }
                    }
-                   success(model, paginationInfo);
+                   success(model, paginationInfo, responseDictionary);
                }
            }
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0)
@@ -366,7 +366,7 @@ typedef enum
                failure(error,[[operation response] statusCode]);
 #else
            failure:^(NSURLSessionDataTask *task, NSError *error) {
-               failure(error,((NSHTTPURLResponse *)[task response]).statusCode);
+               failure(error, ((NSHTTPURLResponse *)[task response]).statusCode);
 #endif
            }];
 }
@@ -467,19 +467,19 @@ typedef enum
 
 
 - (void)getMedia:(NSString *)mediaId
-     withSuccess:(void (^)(InstagramMedia *media))success
+     withSuccess:(void (^)(InstagramMedia *media, NSDictionary *serverResponse))success
          failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"media/%@",mediaId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"media/%@",mediaId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			InstagramMedia *media = response;
-			success(media);
+			success(media, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -488,16 +488,16 @@ typedef enum
 - (void)getPopularMediaWithSuccess:(InstagramMediaBlock)success
                            failure:(InstagramFailureBlock)failure
 {
-    [self getPath:@"media/popular" parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:@"media/popular" parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         NSArray *objects = response;
         if(success)
 		{
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -507,16 +507,16 @@ typedef enum
                withSuccess:(InstagramMediaBlock)success
                    failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"media/search?lat=%f&lng=%f",location.latitude,location.longitude] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"media/search?lat=%f&lng=%f",location.latitude,location.longitude] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -527,16 +527,16 @@ typedef enum
                    failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
-    [self getPath:[NSString stringWithFormat:@"media/search?lat=%f&lng=%f",location.latitude,location.longitude] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"media/search?lat=%f&lng=%f",location.latitude,location.longitude] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -546,19 +546,19 @@ typedef enum
 
 
 - (void)getUserDetails:(NSString *)userId
-           withSuccess:(void (^)(InstagramUser *userDetail))success
+           withSuccess:(void (^)(InstagramUser *userDetail, NSDictionary *serverResponse))success
                failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/%@",userId]  parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/%@",userId]  parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			InstagramUser *userDetail = response;
-			success(userDetail);
+			success(userDetail, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -568,16 +568,16 @@ typedef enum
             withSuccess:(InstagramMediaBlock)success
                 failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/%@/media/recent",userId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/%@/media/recent",userId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -588,35 +588,35 @@ typedef enum
                 failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
-    [self getPath:[NSString stringWithFormat:@"users/%@/media/recent",userId] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/%@/media/recent",userId] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
 
 
 - (void)searchUsersWithString:(NSString *)string
-               withSuccess:(void (^)(NSArray *users, InstagramPaginationInfo *paginationInfo))success
+               withSuccess:(void (^)(NSArray *users, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
                    failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/search?q=%@",string] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/search?q=%@",string] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -625,19 +625,19 @@ typedef enum
 #pragma mark - Self -
 
 
-- (void)getSelfUserDetailsWithSuccess:(void (^)(InstagramUser *userDetail))success
+- (void)getSelfUserDetailsWithSuccess:(InstagramSelfUserBlock)success
                              failure:(InstagramFailureBlock)failure
 {
-    [self getPath:@"users/self" parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:@"users/self" parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         InstagramUser *userDetail = response;
 		if(success)
 		{
-			success(userDetail);
+			success(userDetail, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -646,16 +646,16 @@ typedef enum
 - (void)getSelfFeedWithSuccess:(InstagramMediaBlock)success
             failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -666,16 +666,16 @@ typedef enum
                        failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
-    [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -684,16 +684,16 @@ typedef enum
 - (void)getMediaLikedBySelfWithSuccess:(InstagramMediaBlock)success
                         failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/self/media/liked"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/self/media/liked"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -704,16 +704,16 @@ typedef enum
                              failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxLikeId];
-    [self getPath:[NSString stringWithFormat:@"users/self/media/liked"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/self/media/liked"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -721,16 +721,16 @@ typedef enum
 - (void)getSelfRecentMediaWithSuccess:(InstagramMediaBlock)success
 							failure:(InstagramFailureBlock)failure
 {
-	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
 		if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
 	} failure:^(NSError *error, NSInteger statusCode) {
 		if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
 	}];
 }
@@ -741,16 +741,16 @@ typedef enum
 								failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
-	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
 		if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
 	} failure:^(NSError *error, NSInteger statusCode) {
 		if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
 	}];
 }
@@ -759,19 +759,19 @@ typedef enum
 
 
 - (void)getTagDetailsWithName:(NSString *)name
-                  withSuccess:(void (^)(InstagramTag *tag))success
+                  withSuccess:(void (^)(InstagramTag *tag, NSDictionary *serverResponse))success
                       failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"tags/%@",name] parameters:nil responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"tags/%@",name] parameters:nil responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			InstagramTag *tag = response;
-			success(tag);
+			success(tag, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -781,16 +781,16 @@ typedef enum
                 withSuccess:(InstagramMediaBlock)success
                     failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"tags/%@/media/recent",tag] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"tags/%@/media/recent",tag] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -801,16 +801,16 @@ typedef enum
                     failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxTagId];
-    [self getPath:[NSString stringWithFormat:@"tags/%@/media/recent",tag] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"tags/%@/media/recent",tag] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
 		if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -820,16 +820,16 @@ typedef enum
             withSuccess:(InstagramTagsBlock)success
                 failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"tags/search?q=%@",name] parameters:nil responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"tags/search?q=%@",name] parameters:nil responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -840,16 +840,16 @@ typedef enum
                    failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
-    [self getPath:[NSString stringWithFormat:@"tags/search?q=%@",name] parameters:params responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"tags/search?q=%@",name] parameters:params responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -862,16 +862,16 @@ typedef enum
                withSuccess:(InstagramCommentsBlock)success
                    failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"media/%@/comments",mediaId] parameters:nil responseModel:[InstagramComment class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"media/%@/comments",mediaId] parameters:nil responseModel:[InstagramComment class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects);
+			success(objects, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -893,7 +893,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -912,7 +912,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, nil);
 		}
     }];
 }
@@ -925,7 +925,7 @@ typedef enum
             withSuccess:(void (^)(NSArray *likedUsers))success
                 failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"media/%@/likes",mediaId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"media/%@/likes",mediaId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
@@ -934,7 +934,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, nil);
 		}
     }];
 }
@@ -953,7 +953,7 @@ typedef enum
      } failure:^(NSError *error, NSInteger statusCode) {
          if(failure)
          {
-             failure(error);
+             failure(error, nil);
          }
      }];
 }
@@ -971,7 +971,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, nil);
 		}
     }];
 }
@@ -981,19 +981,19 @@ typedef enum
 
 
 - (void)getRelationshipStatusOfUser:(NSString *)userId
-                          withSuccess:(void (^)(NSDictionary *responseDictionary))success
-                              failure:(void (^)(NSError* error))failure
+                          withSuccess:(void (^)(NSDictionary *responseDictionary, NSDictionary *serverResponse))success
+                              failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:nil responseModel:[NSDictionary class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:nil responseModel:[NSDictionary class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSDictionary *responseDictionary = response;
-			success(responseDictionary);
+			success(responseDictionary, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -1003,16 +1003,16 @@ typedef enum
                    withSuccess:(InstagramObjectsBlock)success
                        failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/%@/follows",userId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/%@/follows",userId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -1022,16 +1022,16 @@ typedef enum
                    withSuccess:(InstagramObjectsBlock)success
                        failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/%@/followed-by",userId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/%@/followed-by",userId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -1040,16 +1040,16 @@ typedef enum
 - (void)getFollowRequestsWithSuccess:(InstagramObjectsBlock)success
                    failure:(InstagramFailureBlock)failure
 {
-    [self getPath:[NSString stringWithFormat:@"users/self/requested-by"] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
+    [self getPath:[NSString stringWithFormat:@"users/self/requested-by"] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -1057,7 +1057,7 @@ typedef enum
 
 - (void)followUser:(NSString *)userId
        withSuccess:(void (^)(NSDictionary *response))success
-           failure:(void (^)(NSError* error))failure
+           failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionFollow};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1069,7 +1069,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
                 if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
         NSLog(@"%@", [error description]);
     }];
@@ -1078,7 +1078,7 @@ typedef enum
 
 - (void)unfollowUser:(NSString *)userId
        withSuccess:(void (^)(NSDictionary *response))success
-           failure:(void (^)(NSError* error))failure
+           failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionUnfollow};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1090,7 +1090,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
                 if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
         NSLog(@"%@", [error description]);
     }];
@@ -1099,7 +1099,7 @@ typedef enum
 
 - (void)blockUser:(NSString *)userId
        withSuccess:(void (^)(NSDictionary *response))success
-           failure:(void (^)(NSError* error))failure
+           failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionBlock};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1111,7 +1111,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
                 if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
         NSLog(@"%@", [error description]);
     }];
@@ -1120,7 +1120,7 @@ typedef enum
 
 - (void)unblockUser:(NSString *)userId
          withSuccess:(void (^)(NSDictionary *response))success
-             failure:(void (^)(NSError* error))failure
+             failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionUnblock};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1132,7 +1132,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
                 if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
         NSLog(@"%@", [error description]);
     }];
@@ -1141,7 +1141,7 @@ typedef enum
 
 - (void)approveUser:(NSString *)userId
       withSuccess:(void (^)(NSDictionary *response))success
-          failure:(void (^)(NSError* error))failure
+          failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionApprove};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1153,7 +1153,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
                 if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
         NSLog(@"%@", [error description]);
     }];
@@ -1162,7 +1162,7 @@ typedef enum
 
 - (void)denyUser:(NSString *)userId
         withSuccess:(void (^)(NSDictionary *response))success
-            failure:(void (^)(NSError* error))failure
+            failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionDeny};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject) {
@@ -1173,7 +1173,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
                 if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
         NSLog(@"%@", [error description]);
     }];
@@ -1184,23 +1184,23 @@ typedef enum
 
 
 - (void)getPaginatedItemsForInfo:(InstagramPaginationInfo *)paginationInfo
-                     withSuccess:(void (^)(NSArray *objects, InstagramPaginationInfo *paginationInfo))success
+                     withSuccess:(void (^)(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
                          failure:(InstagramFailureBlock)failure
 {
     NSString *relativePath = [[paginationInfo.nextURL absoluteString] stringByReplacingOccurrencesOfString:[self.httpManager.baseURL absoluteString] withString:@""];
-    [self getPath:relativePath parameters:nil responseModel:paginationInfo.type success:^(id response, InstagramPaginationInfo *paginationInfo) {
-        
+    [self getPath:relativePath parameters:nil responseModel:paginationInfo.type success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
+
 		if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects, paginationInfo, serverResponse);
 		}
-		
+
     } failure:^(NSError *error, NSInteger statusCode) {
-        
+
 		if(failure)
 		{
-			failure(error);
+			failure(error, statusCode);
 		}
 		
     }];

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -283,6 +283,11 @@ typedef enum
     
 }
 
+- (BOOL)isSessionValid
+{
+    return self.accessToken != nil;
+}
+
 -(NSDictionary*)queryStringParametersFromString:(NSString*)string {
 
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -472,8 +472,8 @@ typedef enum
 
 
 - (void)getMedia:(NSString *)mediaId
- withSuccess:(InstagramMediaBlock)success
-                     failure:(InstagramFailureBlock)failure
+     withSuccess:(InstagramMediaBlock)success
+         failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"media/%@",mediaId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -527,7 +527,9 @@ typedef enum
 }
 
 
-- (void)getMediaAtLocation:(CLLocationCoordinate2D)location count:(NSInteger)count maxId:(NSString *)maxId
+- (void)getMediaAtLocation:(CLLocationCoordinate2D)location
+                     count:(NSInteger)count
+                     maxId:(NSString *)maxId
                withSuccess:(InstagramMediaListBlock)success
                    failure:(InstagramFailureBlock)failure
 {
@@ -551,7 +553,7 @@ typedef enum
 
 
 - (void)getUserDetails:(NSString *)userId
-           withSuccess:(void (^)(InstagramUser *userDetail, NSDictionary *serverResponse))success
+           withSuccess:(InstagramSelfUserBlock)success
                failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/%@",userId]  parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -588,7 +590,9 @@ typedef enum
 }
 
 
-- (void)getMediaForUser:(NSString *)userId count:(NSInteger)count maxId:(NSString *)maxId
+- (void)getMediaForUser:(NSString *)userId
+                  count:(NSInteger)count
+                  maxId:(NSString *)maxId
             withSuccess:(InstagramMediaListBlock)success
                 failure:(InstagramFailureBlock)failure
 {
@@ -609,8 +613,8 @@ typedef enum
 
 
 - (void)searchUsersWithString:(NSString *)string
-               withSuccess:(void (^)(NSArray *users, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
-                   failure:(InstagramFailureBlock)failure
+                  withSuccess:(InstagramUsersBlock)success
+                      failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/search?q=%@",string] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -631,7 +635,7 @@ typedef enum
 
 
 - (void)getSelfUserDetailsWithSuccess:(InstagramSelfUserBlock)success
-                             failure:(InstagramFailureBlock)failure
+                              failure:(InstagramFailureBlock)failure
 {
     [self getPath:@"users/self" parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         InstagramUser *userDetail = response;
@@ -649,7 +653,7 @@ typedef enum
 
 
 - (void)getSelfFeedWithSuccess:(InstagramMediaListBlock)success
-            failure:(InstagramFailureBlock)failure
+                       failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -666,9 +670,10 @@ typedef enum
 }
 
 
-- (void)getSelfFeedWithCount:(NSInteger)count maxId:(NSString *)maxId
+- (void)getSelfFeedWithCount:(NSInteger)count
+                       maxId:(NSString *)maxId
                      success:(InstagramMediaListBlock)success
-                       failure:(InstagramFailureBlock)failure
+                     failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
     [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -687,7 +692,7 @@ typedef enum
 
 
 - (void)getMediaLikedBySelfWithSuccess:(InstagramMediaListBlock)success
-                        failure:(InstagramFailureBlock)failure
+                               failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/self/media/liked"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -705,7 +710,7 @@ typedef enum
 
 
 - (void)getMediaLikedBySelfWithCount:(NSInteger)count
-                     maxId:(NSString *)maxId
+                               maxId:(NSString *)maxId
                              success:(InstagramMediaListBlock)success
                              failure:(InstagramFailureBlock)failure
 {
@@ -725,7 +730,7 @@ typedef enum
 }
 
 - (void)getSelfRecentMediaWithSuccess:(InstagramMediaListBlock)success
-							failure:(InstagramFailureBlock)failure
+							  failure:(InstagramFailureBlock)failure
 {
 	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
 		if(success)
@@ -742,9 +747,10 @@ typedef enum
 }
 
 
-- (void)getSelfRecentMediaWithCount:(NSInteger)count maxId:(NSString *)maxId
-								success:(InstagramMediaListBlock)success
-								failure:(InstagramFailureBlock)failure
+- (void)getSelfRecentMediaWithCount:(NSInteger)count
+                              maxId:(NSString *)maxId
+                            success:(InstagramMediaListBlock)success
+                            failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
 	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:params responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -765,7 +771,7 @@ typedef enum
 
 
 - (void)getTagDetailsWithName:(NSString *)name
-                  withSuccess:(void (^)(InstagramTag *tag, NSDictionary *serverResponse))success
+                  withSuccess:(InstagramTagBlock)success
                       failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"tags/%@",name] parameters:nil responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -802,7 +808,9 @@ typedef enum
 }
 
 
-- (void)getMediaWithTagName:(NSString *)tag count:(NSInteger)count maxId:(NSString *)maxId
+- (void)getMediaWithTagName:(NSString *)tag
+                      count:(NSInteger)count
+                      maxId:(NSString *)maxId
                 withSuccess:(InstagramMediaListBlock)success
                     failure:(InstagramFailureBlock)failure
 {
@@ -823,8 +831,8 @@ typedef enum
 
 
 - (void)searchTagsWithName:(NSString *)name
-            withSuccess:(InstagramTagsBlock)success
-                failure:(InstagramFailureBlock)failure
+               withSuccess:(InstagramTagsBlock)success
+                   failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"tags/search?q=%@",name] parameters:nil responseModel:[InstagramTag class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -841,7 +849,9 @@ typedef enum
 }
 
 
-- (void)searchTagsWithName:(NSString *)name count:(NSInteger)count maxId:(NSString *)maxId
+- (void)searchTagsWithName:(NSString *)name
+                     count:(NSInteger)count
+                     maxId:(NSString *)maxId
                withSuccess:(InstagramTagsBlock)success
                    failure:(InstagramFailureBlock)failure
 {
@@ -885,7 +895,7 @@ typedef enum
 
 - (void)createComment:(NSString *)commentText
               onMedia:(NSString *)mediaId
-          withSuccess:(void (^)(void))success
+          withSuccess:(dispatch_block_t)success
               failure:(InstagramFailureBlock)failure
 {
     // Please email apidevelopers@instagram.com for access.
@@ -907,7 +917,7 @@ typedef enum
 
 - (void)removeComment:(NSString *)commentId
               onMedia:(NSString *)mediaId
-          withSuccess:(void (^)(void))success
+          withSuccess:(dispatch_block_t)success
               failure:(InstagramFailureBlock)failure
 {
     [self deletePath:[NSString stringWithFormat:@"media/%@/comments/%@",mediaId,commentId] parameters:nil responseModel:nil success:^{
@@ -947,7 +957,7 @@ typedef enum
 
 
 - (void)likeMedia:(NSString *)mediaId
-      withSuccess:(void (^)(void))success
+      withSuccess:(dispatch_block_t)success
           failure:(InstagramFailureBlock)failure
 {
     [self postPath:[NSString stringWithFormat:@"media/%@/likes",mediaId] parameters:nil responseModel:nil success:^(NSDictionary *responseObject)
@@ -966,7 +976,7 @@ typedef enum
 
 
 - (void)unlikeMedia:(NSString *)mediaId
-        withSuccess:(void (^)(void))success
+        withSuccess:(dispatch_block_t)success
             failure:(InstagramFailureBlock)failure
 {
     [self deletePath:[NSString stringWithFormat:@"media/%@/likes",mediaId] parameters:nil responseModel:nil success:^{
@@ -987,8 +997,8 @@ typedef enum
 
 
 - (void)getRelationshipStatusOfUser:(NSString *)userId
-                          withSuccess:(InstagramGenericResponseBlock)success
-                              failure:(InstagramFailureBlock)failure
+                        withSuccess:(InstagramGenericResponseBlock)success
+                            failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:nil responseModel:[NSDictionary class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -1025,8 +1035,8 @@ typedef enum
 
 
 - (void)getFollowersOfUser:(NSString *)userId
-                   withSuccess:(InstagramObjectsBlock)success
-                       failure:(InstagramFailureBlock)failure
+               withSuccess:(InstagramObjectsBlock)success
+                   failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/%@/followed-by",userId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -1044,7 +1054,7 @@ typedef enum
 
 
 - (void)getFollowRequestsWithSuccess:(InstagramObjectsBlock)success
-                   failure:(InstagramFailureBlock)failure
+                             failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/self/requested-by"] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -1062,7 +1072,7 @@ typedef enum
 
 
 - (void)followUser:(NSString *)userId
-       withSuccess:(void (^)(NSDictionary *response))success
+       withSuccess:(InstagramGenericResponseBlock)success
            failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionFollow};
@@ -1083,8 +1093,8 @@ typedef enum
 
 
 - (void)unfollowUser:(NSString *)userId
-       withSuccess:(void (^)(NSDictionary *response))success
-           failure:(InstagramFailureBlock)failure
+         withSuccess:(InstagramGenericResponseBlock)success
+             failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionUnfollow};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1104,8 +1114,8 @@ typedef enum
 
 
 - (void)blockUser:(NSString *)userId
-       withSuccess:(void (^)(NSDictionary *response))success
-           failure:(InstagramFailureBlock)failure
+      withSuccess:(InstagramGenericResponseBlock)success
+          failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionBlock};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1125,8 +1135,8 @@ typedef enum
 
 
 - (void)unblockUser:(NSString *)userId
-         withSuccess:(void (^)(NSDictionary *response))success
-             failure:(InstagramFailureBlock)failure
+        withSuccess:(InstagramGenericResponseBlock)success
+            failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionUnblock};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1146,8 +1156,8 @@ typedef enum
 
 
 - (void)approveUser:(NSString *)userId
-      withSuccess:(void (^)(NSDictionary *response))success
-          failure:(InstagramFailureBlock)failure
+        withSuccess:(InstagramGenericResponseBlock)success
+            failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionApprove};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject)
@@ -1167,8 +1177,8 @@ typedef enum
 
 
 - (void)denyUser:(NSString *)userId
-        withSuccess:(void (^)(NSDictionary *response))success
-            failure:(InstagramFailureBlock)failure
+     withSuccess:(InstagramGenericResponseBlock)success
+         failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = @{kRelationshipActionKey:kRelationshipActionDeny};
     [self postPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:params responseModel:nil success:^(NSDictionary *responseObject) {
@@ -1190,7 +1200,7 @@ typedef enum
 
 
 - (void)getPaginatedItemsForInfo:(InstagramPaginationInfo *)paginationInfo
-                     withSuccess:(void (^)(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse))success
+                     withSuccess:(InstagramObjectsBlock)success
                          failure:(InstagramFailureBlock)failure
 {
     NSString *relativePath = [[paginationInfo.nextURL absoluteString] stringByReplacingOccurrencesOfString:[self.httpManager.baseURL absoluteString] withString:@""];

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -472,8 +472,8 @@ typedef enum
 
 
 - (void)getMedia:(NSString *)mediaId
-     withSuccess:(void (^)(InstagramMedia *media, NSDictionary *serverResponse))success
-         failure:(InstagramFailureBlock)failure
+ withSuccess:(InstagramMediaBlock)success
+                     failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"media/%@",mediaId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
@@ -490,7 +490,7 @@ typedef enum
 }
 
 
-- (void)getPopularMediaWithSuccess:(InstagramMediaBlock)success
+- (void)getPopularMediaWithSuccess:(InstagramMediaListBlock)success
                            failure:(InstagramFailureBlock)failure
 {
     [self getPath:@"media/popular" parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -509,7 +509,7 @@ typedef enum
 
 
 - (void)getMediaAtLocation:(CLLocationCoordinate2D)location
-               withSuccess:(InstagramMediaBlock)success
+               withSuccess:(InstagramMediaListBlock)success
                    failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"media/search?lat=%f&lng=%f",location.latitude,location.longitude] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -528,7 +528,7 @@ typedef enum
 
 
 - (void)getMediaAtLocation:(CLLocationCoordinate2D)location count:(NSInteger)count maxId:(NSString *)maxId
-               withSuccess:(InstagramMediaBlock)success
+               withSuccess:(InstagramMediaListBlock)success
                    failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
@@ -570,7 +570,7 @@ typedef enum
 
 
 - (void)getMediaForUser:(NSString *)userId
-            withSuccess:(InstagramMediaBlock)success
+            withSuccess:(InstagramMediaListBlock)success
                 failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/%@/media/recent",userId] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -589,7 +589,7 @@ typedef enum
 
 
 - (void)getMediaForUser:(NSString *)userId count:(NSInteger)count maxId:(NSString *)maxId
-            withSuccess:(InstagramMediaBlock)success
+            withSuccess:(InstagramMediaListBlock)success
                 failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
@@ -648,7 +648,7 @@ typedef enum
 }
 
 
-- (void)getSelfFeedWithSuccess:(InstagramMediaBlock)success
+- (void)getSelfFeedWithSuccess:(InstagramMediaListBlock)success
             failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/self/feed"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -667,7 +667,7 @@ typedef enum
 
 
 - (void)getSelfFeedWithCount:(NSInteger)count maxId:(NSString *)maxId
-                     success:(InstagramMediaBlock)success
+                     success:(InstagramMediaListBlock)success
                        failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
@@ -686,7 +686,7 @@ typedef enum
 }
 
 
-- (void)getMediaLikedBySelfWithSuccess:(InstagramMediaBlock)success
+- (void)getMediaLikedBySelfWithSuccess:(InstagramMediaListBlock)success
                         failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/self/media/liked"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -704,8 +704,9 @@ typedef enum
 }
 
 
-- (void)getMediaLikedBySelfWithCount:(NSInteger)count maxId:(NSString *)maxId
-                             success:(InstagramMediaBlock)success
+- (void)getMediaLikedBySelfWithCount:(NSInteger)count
+                     maxId:(NSString *)maxId
+                             success:(InstagramMediaListBlock)success
                              failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxLikeId];
@@ -723,7 +724,7 @@ typedef enum
     }];
 }
 
-- (void)getSelfRecentMediaWithSuccess:(InstagramMediaBlock)success
+- (void)getSelfRecentMediaWithSuccess:(InstagramMediaListBlock)success
 							failure:(InstagramFailureBlock)failure
 {
 	[self getPath:[NSString stringWithFormat:@"users/self/media/recent"] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -742,7 +743,7 @@ typedef enum
 
 
 - (void)getSelfRecentMediaWithCount:(NSInteger)count maxId:(NSString *)maxId
-								success:(InstagramMediaBlock)success
+								success:(InstagramMediaListBlock)success
 								failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxId];
@@ -783,7 +784,7 @@ typedef enum
 
 
 - (void)getMediaWithTagName:(NSString *)tag
-                withSuccess:(InstagramMediaBlock)success
+                withSuccess:(InstagramMediaListBlock)success
                     failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"tags/%@/media/recent",tag] parameters:nil responseModel:[InstagramMedia class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
@@ -802,7 +803,7 @@ typedef enum
 
 
 - (void)getMediaWithTagName:(NSString *)tag count:(NSInteger)count maxId:(NSString *)maxId
-                withSuccess:(InstagramMediaBlock)success
+                withSuccess:(InstagramMediaListBlock)success
                     failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self parametersFromCount:count maxId:maxId andMaxIdType:kPaginationMaxTagId];
@@ -917,7 +918,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error, nil);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -927,19 +928,19 @@ typedef enum
 
 
 - (void)getLikesOnMedia:(NSString *)mediaId
-            withSuccess:(void (^)(NSArray *likedUsers))success
+            withSuccess:(InstagramObjectsBlock)success
                 failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"media/%@/likes",mediaId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects);
+			success(objects, paginationInfo, serverResponse);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error, nil);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -958,7 +959,7 @@ typedef enum
      } failure:^(NSError *error, NSInteger statusCode) {
          if(failure)
          {
-             failure(error, nil);
+             failure(error, statusCode);
          }
      }];
 }
@@ -976,7 +977,7 @@ typedef enum
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)
 		{
-			failure(error, nil);
+			failure(error, statusCode);
 		}
     }];
 }
@@ -986,14 +987,14 @@ typedef enum
 
 
 - (void)getRelationshipStatusOfUser:(NSString *)userId
-                          withSuccess:(void (^)(NSDictionary *responseDictionary, NSDictionary *serverResponse))success
+                          withSuccess:(InstagramGenericResponseBlock)success
                               failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"users/%@/relationship",userId] parameters:nil responseModel:[NSDictionary class] success:^(id response, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         if(success)
 		{
 			NSDictionary *responseDictionary = response;
-			success(responseDictionary, serverResponse);
+			success(responseDictionary);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)

--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -57,12 +57,12 @@
 
 - (void)loadUserDetailsWithSuccess:(void(^)(void))success failure:(void(^)(void))failure
 {
-    [[InstagramEngine sharedEngine] getUserDetails:self.Id withSuccess:^(InstagramUser *userDetail) {
+    [[InstagramEngine sharedEngine] getUserDetails:self.Id withSuccess:^(InstagramUser *userDetail, NSDictionary *serverResponse) {
         _mediaCount = userDetail.mediaCount;
         _followsCount = userDetail.followsCount;
         _followedByCount = userDetail.followedByCount;
         success();
-    } failure:^(NSError *error) {
+    } failure:^(NSError* error, NSInteger statusCode) {
         failure();
     }];
 }
@@ -74,10 +74,10 @@
 
 - (void)loadRecentMedia:(NSInteger)count withSuccess:(void(^)(void))success failure:(void(^)(void))failure
 {
-    [[InstagramEngine sharedEngine] getMediaForUser:self.Id withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getMediaForUser:self.Id withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         self.recentMedia = media;
         success();
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         failure();
     }];
 }

--- a/InstagramKitDemo/InstagramKitDemo.xcodeproj/project.pbxproj
+++ b/InstagramKitDemo/InstagramKitDemo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		52781DBA17CD6E8D001A32F7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781DB917CD6E8D001A32F7 /* SystemConfiguration.framework */; };
 		52781DBC17CD6E9B001A32F7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781DBB17CD6E9B001A32F7 /* MobileCoreServices.framework */; };
 		52A3602318C7BD4D00B4CBD7 /* InstagramPaginationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 52A3602218C7BD4D00B4CBD7 /* InstagramPaginationInfo.m */; };
+		6556A5BBE4BA01F08DBB87B8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EA6DA02BF431E5E359DA42A /* libPods.a */; };
 		820D6DC218B7DC6900847053 /* InstagramKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = 820D6DC118B7DC6900847053 /* InstagramKit.plist */; };
 		825BB4BD18A183D800F3BDF3 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 825BB4AB18A183D800F3BDF3 /* AFHTTPRequestOperation.m */; };
 		825BB4BE18A183D800F3BDF3 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 825BB4AD18A183D800F3BDF3 /* AFHTTPRequestOperationManager.m */; };
@@ -60,6 +61,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		01934BC5AC2D3EE370A07F48 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		413015160558108F32DD63A4 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		52781D3817CD6BB9001A32F7 /* InstagramKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InstagramKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52781D3B17CD6BB9001A32F7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		52781D3D17CD6BB9001A32F7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -100,6 +103,7 @@
 		52781DBB17CD6E9B001A32F7 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		52A3602118C7BD4D00B4CBD7 /* InstagramPaginationInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InstagramPaginationInfo.h; sourceTree = "<group>"; };
 		52A3602218C7BD4D00B4CBD7 /* InstagramPaginationInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InstagramPaginationInfo.m; sourceTree = "<group>"; };
+		5EA6DA02BF431E5E359DA42A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		820D6DC118B7DC6900847053 /* InstagramKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = InstagramKit.plist; sourceTree = "<group>"; };
 		825BB4AA18A183D800F3BDF3 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
 		825BB4AB18A183D800F3BDF3 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
@@ -141,6 +145,7 @@
 				52781D3E17CD6BB9001A32F7 /* CoreGraphics.framework in Frameworks */,
 				52781DBC17CD6E9B001A32F7 /* MobileCoreServices.framework in Frameworks */,
 				52781DBA17CD6E8D001A32F7 /* SystemConfiguration.framework in Frameworks */,
+				6556A5BBE4BA01F08DBB87B8 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -166,6 +171,7 @@
 				52781D6017CD6BB9001A32F7 /* InstagramKitDemoTests */,
 				52781D3A17CD6BB9001A32F7 /* Frameworks */,
 				52781D3917CD6BB9001A32F7 /* Products */,
+				D323DC98D6E9FF45859E60CA /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -187,6 +193,7 @@
 				52781D3D17CD6BB9001A32F7 /* CoreGraphics.framework */,
 				52781D3F17CD6BB9001A32F7 /* UIKit.framework */,
 				52781D5A17CD6BB9001A32F7 /* XCTest.framework */,
+				5EA6DA02BF431E5E359DA42A /* libPods.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -337,6 +344,15 @@
 			path = AFNetworking;
 			sourceTree = "<group>";
 		};
+		D323DC98D6E9FF45859E60CA /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				413015160558108F32DD63A4 /* Pods.debug.xcconfig */,
+				01934BC5AC2D3EE370A07F48 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -344,9 +360,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 52781D6A17CD6BB9001A32F7 /* Build configuration list for PBXNativeTarget "InstagramKitDemo" */;
 			buildPhases = (
+				3105B5061CAD566D78D856A3 /* Check Pods Manifest.lock */,
 				52781D3417CD6BB9001A32F7 /* Sources */,
 				52781D3517CD6BB9001A32F7 /* Frameworks */,
 				52781D3617CD6BB9001A32F7 /* Resources */,
+				3FEED3F61AD6D8AE8D0F8CD5 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -430,6 +448,39 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3105B5061CAD566D78D856A3 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		3FEED3F61AD6D8AE8D0F8CD5 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		52781D3417CD6BB9001A32F7 /* Sources */ = {
@@ -580,6 +631,7 @@
 		};
 		52781D6B17CD6BB9001A32F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 413015160558108F32DD63A4 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -594,6 +646,7 @@
 		};
 		52781D6C17CD6BB9001A32F7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 01934BC5AC2D3EE370A07F48 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/InstagramKitDemo/InstagramKitDemo.xcodeproj/project.pbxproj
+++ b/InstagramKitDemo/InstagramKitDemo.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		52781DBA17CD6E8D001A32F7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781DB917CD6E8D001A32F7 /* SystemConfiguration.framework */; };
 		52781DBC17CD6E9B001A32F7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52781DBB17CD6E9B001A32F7 /* MobileCoreServices.framework */; };
 		52A3602318C7BD4D00B4CBD7 /* InstagramPaginationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 52A3602218C7BD4D00B4CBD7 /* InstagramPaginationInfo.m */; };
-		6556A5BBE4BA01F08DBB87B8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EA6DA02BF431E5E359DA42A /* libPods.a */; };
 		820D6DC218B7DC6900847053 /* InstagramKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = 820D6DC118B7DC6900847053 /* InstagramKit.plist */; };
 		825BB4BD18A183D800F3BDF3 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 825BB4AB18A183D800F3BDF3 /* AFHTTPRequestOperation.m */; };
 		825BB4BE18A183D800F3BDF3 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 825BB4AD18A183D800F3BDF3 /* AFHTTPRequestOperationManager.m */; };
@@ -61,8 +60,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		01934BC5AC2D3EE370A07F48 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		413015160558108F32DD63A4 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		52781D3817CD6BB9001A32F7 /* InstagramKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InstagramKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52781D3B17CD6BB9001A32F7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		52781D3D17CD6BB9001A32F7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -103,7 +100,6 @@
 		52781DBB17CD6E9B001A32F7 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		52A3602118C7BD4D00B4CBD7 /* InstagramPaginationInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InstagramPaginationInfo.h; sourceTree = "<group>"; };
 		52A3602218C7BD4D00B4CBD7 /* InstagramPaginationInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InstagramPaginationInfo.m; sourceTree = "<group>"; };
-		5EA6DA02BF431E5E359DA42A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		820D6DC118B7DC6900847053 /* InstagramKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = InstagramKit.plist; sourceTree = "<group>"; };
 		825BB4AA18A183D800F3BDF3 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
 		825BB4AB18A183D800F3BDF3 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
@@ -145,7 +141,6 @@
 				52781D3E17CD6BB9001A32F7 /* CoreGraphics.framework in Frameworks */,
 				52781DBC17CD6E9B001A32F7 /* MobileCoreServices.framework in Frameworks */,
 				52781DBA17CD6E8D001A32F7 /* SystemConfiguration.framework in Frameworks */,
-				6556A5BBE4BA01F08DBB87B8 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -171,7 +166,6 @@
 				52781D6017CD6BB9001A32F7 /* InstagramKitDemoTests */,
 				52781D3A17CD6BB9001A32F7 /* Frameworks */,
 				52781D3917CD6BB9001A32F7 /* Products */,
-				D323DC98D6E9FF45859E60CA /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -193,7 +187,6 @@
 				52781D3D17CD6BB9001A32F7 /* CoreGraphics.framework */,
 				52781D3F17CD6BB9001A32F7 /* UIKit.framework */,
 				52781D5A17CD6BB9001A32F7 /* XCTest.framework */,
-				5EA6DA02BF431E5E359DA42A /* libPods.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -344,15 +337,6 @@
 			path = AFNetworking;
 			sourceTree = "<group>";
 		};
-		D323DC98D6E9FF45859E60CA /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				413015160558108F32DD63A4 /* Pods.debug.xcconfig */,
-				01934BC5AC2D3EE370A07F48 /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -360,11 +344,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 52781D6A17CD6BB9001A32F7 /* Build configuration list for PBXNativeTarget "InstagramKitDemo" */;
 			buildPhases = (
-				3105B5061CAD566D78D856A3 /* Check Pods Manifest.lock */,
 				52781D3417CD6BB9001A32F7 /* Sources */,
 				52781D3517CD6BB9001A32F7 /* Frameworks */,
 				52781D3617CD6BB9001A32F7 /* Resources */,
-				3FEED3F61AD6D8AE8D0F8CD5 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -448,39 +430,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		3105B5061CAD566D78D856A3 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		3FEED3F61AD6D8AE8D0F8CD5 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		52781D3417CD6BB9001A32F7 /* Sources */ = {
@@ -631,7 +580,6 @@
 		};
 		52781D6B17CD6BB9001A32F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 413015160558108F32DD63A4 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -646,7 +594,6 @@
 		};
 		52781D6C17CD6BB9001A32F7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 01934BC5AC2D3EE370A07F48 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/InstagramKitDemo/InstagramKitDemo/Classes/View/IKCollectionViewController.m
+++ b/InstagramKitDemo/InstagramKitDemo/Classes/View/IKCollectionViewController.m
@@ -98,11 +98,11 @@
 
 - (void)testLoadPopularMedia
 {
-    [[InstagramEngine sharedEngine] getPopularMediaWithSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getPopularMediaWithSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         [mediaArray removeAllObjects];
         [mediaArray addObjectsFromArray:media];
         [self reloadData];
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Load Popular Media Failed");
     }];
 
@@ -110,9 +110,9 @@
 
 - (void)getSelfUserDetails
 {
-    [[InstagramEngine sharedEngine] getSelfUserDetailsWithSuccess:^(InstagramUser *userDetail) {
+    [[InstagramEngine sharedEngine] getSelfUserDetailsWithSuccess:^(InstagramUser *userDetail, NSDictionary *serverResponse) {
         NSLog(@"%@",userDetail);
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         
     }];
 }
@@ -120,13 +120,13 @@
 
 - (void)testLoadSelfFeed
 {
-    [[InstagramEngine sharedEngine] getSelfFeedWithCount:15 maxId:self.currentPaginationInfo.nextMaxId success:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getSelfFeedWithCount:15 maxId:self.currentPaginationInfo.nextMaxId success:^(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         self.currentPaginationInfo = paginationInfo;
         
         [mediaArray addObjectsFromArray:media];
         
         [self reloadData];
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Request Self Feed Failed");
     }];
 }
@@ -134,13 +134,13 @@
 
 - (void)testLoadSelfLikedMedia
 {
-    [[InstagramEngine sharedEngine] getMediaLikedBySelfWithCount:15 maxId:self.currentPaginationInfo.nextMaxId success:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getMediaLikedBySelfWithCount:15 maxId:self.currentPaginationInfo.nextMaxId success:^(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         self.currentPaginationInfo = paginationInfo;
         
         [mediaArray addObjectsFromArray:media];
         
         [self reloadData];
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Request Self Liked Media Failed");
         
     }];
@@ -149,28 +149,28 @@
 
 - (void)testSearchUsersWithString:(NSString *)string
 {
-    [[InstagramEngine sharedEngine] searchUsersWithString:string withSuccess:^(NSArray *users, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] searchUsersWithString:string withSuccess:^(NSArray *users, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         NSLog(@"%ld users found", (long)users.count);
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"user search failed");
     }];
 }
 
 - (void)testGetMediaFromTag:(NSString *)tag
 {
-    [[InstagramEngine sharedEngine] getMediaWithTagName:tag count:15 maxId:self.currentPaginationInfo.nextMaxId withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getMediaWithTagName:tag count:15 maxId:self.currentPaginationInfo.nextMaxId withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         self.currentPaginationInfo = paginationInfo;
         [mediaArray addObjectsFromArray:media];
         [self reloadData];
         
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Search Media Failed");
     }];
 }
 
 - (void)testLoadMediaForUser:(InstagramUser *)user
 {
-    [[InstagramEngine sharedEngine] getMediaForUser:user.Id count:15 maxId:self.currentPaginationInfo.nextMaxId withSuccess:^(NSArray *feed, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getMediaForUser:user.Id count:15 maxId:self.currentPaginationInfo.nextMaxId withSuccess:^(NSArray *feed, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
 
         if (paginationInfo) {
             self.currentPaginationInfo = paginationInfo;
@@ -179,20 +179,20 @@
         [mediaArray addObjectsFromArray:feed];
         [self reloadData];
         
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Loading User media failed");
     }];
 }
 
 - (void)testPaginationRequest:(InstagramPaginationInfo *)pInfo
 {
-    [[InstagramEngine sharedEngine] getPaginatedItemsForInfo:self.currentPaginationInfo withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getPaginatedItemsForInfo:self.currentPaginationInfo withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         NSLog(@"%ld more media in Pagination",(unsigned long)media.count);
         self.currentPaginationInfo = paginationInfo;
         [mediaArray addObjectsFromArray:media];
         [self reloadData];
         
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Pagination Failed");
     }];
 }

--- a/InstagramKitDemo/InstagramKitDemo/Classes/View/IKMediaViewController.m
+++ b/InstagramKitDemo/InstagramKitDemo/Classes/View/IKMediaViewController.m
@@ -162,9 +162,9 @@
 
 - (void)testGetMedia
 {
-    [[InstagramEngine sharedEngine] getMedia:self.media.Id withSuccess:^(InstagramMedia *media) {
+    [[InstagramEngine sharedEngine] getMedia:self.media.Id withSuccess:^(InstagramMedia *media, NSDictionary *serverResponse) {
         NSLog(@"Load Media Successful");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Loading Media Failed");
     }];
 }
@@ -181,11 +181,11 @@
 
 - (void)testComments
 {
-    [[InstagramEngine sharedEngine] getCommentsOnMedia:self.media.Id withSuccess:^(NSArray *comments) {
+    [[InstagramEngine sharedEngine] getCommentsOnMedia:self.media.Id withSuccess:^(NSArray *comments, NSDictionary *serverResponse) {
         for (InstagramComment *comment in comments) {
             NSLog(@"@%@: %@",comment.user.username, comment.text);
         }
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Could not load comments");
     }];
 }
@@ -196,7 +196,7 @@
         for (InstagramUser *user in likedUsers) {
             NSLog(@"Like : @%@",user.username);
         }
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Could not load likes");
     }];
 }
@@ -207,7 +207,7 @@
         liked = YES;
         [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:0]] withRowAnimation:UITableViewRowAnimationNone];
         NSLog(@"Like Success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Like Failure");
     }];
 }
@@ -219,7 +219,7 @@
         NSLog(@"Unlike Success");
         [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:0]] withRowAnimation:UITableViewRowAnimationNone];
 
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Unlike Failure");
     }];
 }
@@ -228,7 +228,7 @@
 {
     [[InstagramEngine sharedEngine] createComment:@"Test" onMedia:self.media.Id withSuccess:^{
         NSLog(@"Create Comment Success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Create Comment Failure");
     }];
 }
@@ -250,17 +250,17 @@
 
 - (void)testRelationshipStatusOfUser:(NSString *)userId
 {
-    [[InstagramEngine sharedEngine] getRelationshipStatusOfUser:userId withSuccess:^(NSDictionary *responseDictionary) {
+    [[InstagramEngine sharedEngine] getRelationshipStatusOfUser:userId withSuccess:^(NSDictionary *responseDictionary, NSDictionary *serverResponse) {
         NSLog(@"responseDictionary %@",responseDictionary);
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"fail %@",error);
     }];
 }
 - (void)testGetUsersFollowedByUser:(NSString *)userId
 {
-    [[InstagramEngine sharedEngine] getUsersFollowedByUser:userId withSuccess:^(NSArray *objects, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getUsersFollowedByUser:userId withSuccess:^(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         NSLog(@"Get Follows Success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Get Follows Failure");
  
     }];
@@ -268,10 +268,10 @@
 
 - (void)testGetFollowersOfUser:(NSString *)userId
 {
-    [[InstagramEngine sharedEngine] getFollowersOfUser:userId withSuccess:^(NSArray *objects, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getFollowersOfUser:userId withSuccess:^(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         NSLog(@"Get Followers Success");
         
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Get Followers Failure");
         
     }];
@@ -279,10 +279,10 @@
 
 - (void)getSelfFollowRequests
 {
-    [[InstagramEngine sharedEngine] getFollowRequestsWithSuccess:^(NSArray *objects, InstagramPaginationInfo *paginationInfo) {
+    [[InstagramEngine sharedEngine] getFollowRequestsWithSuccess:^(NSArray *objects, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         NSLog(@"Get Requests Success");
         
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"Get Requests Failure");
         
     }];
@@ -294,7 +294,7 @@
     [[InstagramEngine sharedEngine] followUser:self.media.user.Id withSuccess:^(NSDictionary *response)
     {
         NSLog(@"follow success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"failed to follow");
     }];
 }
@@ -306,7 +306,7 @@
     [[InstagramEngine sharedEngine] unfollowUser:self.media.user.Id withSuccess:^(NSDictionary *response)
     {
         NSLog(@"unfollow success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"failed to unfollow");
     }];
 }
@@ -317,7 +317,7 @@
     [[InstagramEngine sharedEngine] blockUser:self.media.user.Id withSuccess:^(NSDictionary *response)
     {
         NSLog(@"block success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"failed to block");
     }];
 }
@@ -328,7 +328,7 @@
     [[InstagramEngine sharedEngine] unblockUser:self.media.user.Id withSuccess:^(NSDictionary *response)
     {
         NSLog(@"unblock success");
-    } failure:^(NSError *error) {
+    } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"failed to unblock");
     }];
 }

--- a/InstagramKitDemo/InstagramKitDemo/Classes/View/IKMediaViewController.m
+++ b/InstagramKitDemo/InstagramKitDemo/Classes/View/IKMediaViewController.m
@@ -192,7 +192,7 @@
 
 - (void)testGetLikes
 {
-    [[InstagramEngine sharedEngine] getLikesOnMedia:self.media.Id withSuccess:^(NSArray *likedUsers) {
+    [[InstagramEngine sharedEngine] getLikesOnMedia:self.media.Id withSuccess:^(NSArray *likedUsers, InstagramPaginationInfo *paginationInfo, NSDictionary *serverResponse) {
         for (InstagramUser *user in likedUsers) {
             NSLog(@"Like : @%@",user.username);
         }
@@ -250,7 +250,7 @@
 
 - (void)testRelationshipStatusOfUser:(NSString *)userId
 {
-    [[InstagramEngine sharedEngine] getRelationshipStatusOfUser:userId withSuccess:^(NSDictionary *responseDictionary, NSDictionary *serverResponse) {
+    [[InstagramEngine sharedEngine] getRelationshipStatusOfUser:userId withSuccess:^(NSDictionary *responseDictionary) {
         NSLog(@"responseDictionary %@",responseDictionary);
     } failure:^(NSError *error, NSInteger statusCode) {
         NSLog(@"fail %@",error);

--- a/InstagramKitDemo/Podfile
+++ b/InstagramKitDemo/Podfile
@@ -1,4 +1,3 @@
 platform :ios, '6.1'
 
-pod 'AFNetworking', '~> 2.0'
-
+pod 'AFNetworking', '~> 2.5'


### PR DESCRIPTION
Great Lib @shyambhat. It's very convenient to have everything wrapped in model objects. In my case however I needed to access the server response as well, in some cases. I've updated InstagramEngine's completion blocks to include a dictionary of the server response. I also changed the method signatures to use typedef block definitions as some were using them and others were not. 

I decided to contribute back and see if you'll find this useful.