### PR TITLE
Created and utilised InstagramLikesBlock for getLikesOnMedia method.

### DIFF
--- a/InstagramKit/Engine/InstagramEngine.h
+++ b/InstagramKit/Engine/InstagramEngine.h
@@ -35,6 +35,7 @@ typedef void (^InstagramMediaBlock)(NSArray *media, InstagramPaginationInfo *pag
 typedef void (^InstagramObjectsBlock)(NSArray *objects, InstagramPaginationInfo *paginationInfo);
 typedef void (^InstagramTagsBlock)(NSArray *tags, InstagramPaginationInfo *paginationInfo);
 typedef void (^InstagramTagBlock)(InstagramTag *tag);
+typedef void (^InstagramLikesBlock)(NSArray *likes);
 typedef void (^InstagramCommentsBlock)(NSArray *comments);
 typedef void (^InstagramUsersBlock)(NSArray *users, InstagramPaginationInfo *paginationInfo);
 typedef void (^InstagramResponseBlock)(NSDictionary *serverResponse);
@@ -264,7 +265,7 @@ sourceApplication
 
 
 - (void)getLikesOnMedia:(NSString *)mediaId
-            withSuccess:(InstagramObjectsBlock)success
+            withSuccess:(InstagramLikesBlock)success
                 failure:(InstagramFailureBlock)failure;
 
 - (void)likeMedia:(NSString *)mediaId

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -910,14 +910,14 @@ typedef enum
 
 
 - (void)getLikesOnMedia:(NSString *)mediaId
-            withSuccess:(InstagramObjectsBlock)success
+            withSuccess:(InstagramLikesBlock)success
                 failure:(InstagramFailureBlock)failure
 {
     [self getPath:[NSString stringWithFormat:@"media/%@/likes",mediaId] parameters:nil responseModel:[InstagramUser class] success:^(id response, InstagramPaginationInfo *paginationInfo) {
         if(success)
 		{
 			NSArray *objects = response;
-			success(objects, paginationInfo);
+			success(objects);
 		}
     } failure:^(NSError *error, NSInteger statusCode) {
         if(failure)


### PR DESCRIPTION
Instagram doesn't return pagination information when getting likes/comments.
I've created and utilised the InstagramLikesBlock for the getLikesOnMedia just like the getCommentsOnMedia Method.