### PR TITLE
IGMedia imports fixed

### DIFF
--- a/InstagramKit/Models/InstagramMedia.h
+++ b/InstagramKit/Models/InstagramMedia.h
@@ -23,9 +23,9 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import "InstagramModel.h"
 
-@class InstagramUser;
-@class InstagramComment;
-@class InstagramLocation;
+#import "InstagramUser.h"
+#import "InstagramComment.h"
+#import "InstagramLocation.h"
 
 @interface InstagramMedia : InstagramModel
 


### PR DESCRIPTION
I found and fixed an issue when using the @class precompiler macro.
I wasn't able to access an InstagramMedia.user.username property, because InstagramUser was not imported in InstagramMedia.h, just marked with the @class InstagramUser

So I changed the three @class's for #import's , and it works good now.