### PR TITLE
Call super encode/decode on subclasses of InstagramModel to keep ID property persisted

### DIFF
--- a/InstagramKit/Models/InstagramComment.m
+++ b/InstagramKit/Models/InstagramComment.m
@@ -49,7 +49,7 @@
 
 - (id)initWithCoder:(NSCoder *)decoder
 {
-    if ((self = [self init])) {
+    if ((self = [super initWithCoder:decoder])) {
         _user = [decoder decodeObjectOfClass:[InstagramUser class] forKey:kCreator];
         _text = [decoder decodeObjectOfClass:[NSString class] forKey:kText];
         _createdDate = [decoder decodeObjectOfClass:[NSDate class] forKey:kCreatedDate];
@@ -59,6 +59,8 @@
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
+    [super encodeWithCoder:encoder];
+
     [encoder encodeObject:_user forKey:kCreator];
     [encoder encodeObject:_text forKey:kText];
     [encoder encodeObject:_createdDate forKey:kCreatedDate];

--- a/InstagramKit/Models/InstagramLocation.m
+++ b/InstagramKit/Models/InstagramLocation.m
@@ -54,7 +54,7 @@
 
 - (id)initWithCoder:(NSCoder *)decoder
 {
-    if ((self = [self init])) {
+    if ((self = [super initWithCoder:decoder])) {
         CLLocationCoordinate2D coordinates;
         coordinates.latitude = [decoder decodeDoubleForKey:kLocationLatitude];
         coordinates.longitude = [decoder decodeDoubleForKey:kLocationLongitude];
@@ -66,6 +66,8 @@
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
+    [super encodeWithCoder:encoder];
+
     [encoder encodeDouble:_coordinates.latitude forKey:kLocationLatitude];
     [encoder encodeDouble:_coordinates.longitude forKey:kLocationLongitude];
     [encoder encodeObject:_name forKey:kLocationName];

--- a/InstagramKit/Models/InstagramMedia.m
+++ b/InstagramKit/Models/InstagramMedia.m
@@ -121,7 +121,7 @@
 
 - (id)initWithCoder:(NSCoder *)decoder
 {
-    if ((self = [self init])) {
+    if ((self = [super initWithCoder:decoder])) {
         _user = [decoder decodeObjectOfClass:[InstagramUser class] forKey:kUser];
         _userHasLiked = [decoder decodeBoolForKey:kUserHasLiked];
         _createdDate = [decoder decodeObjectOfClass:[NSDate class] forKey:kCreatedDate];
@@ -165,6 +165,8 @@
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
+    [super encodeWithCoder:encoder];
+
     [encoder encodeObject:_user forKey:kUser];
     [encoder encodeBool:_userHasLiked forKey:kUserHasLiked];
     [encoder encodeObject:_createdDate forKey:kCreatedDate];

--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -75,7 +75,7 @@
 
 - (id)initWithCoder:(NSCoder *)decoder
 {
-    if ((self = [self init])) {
+    if ((self = [super initWithCoder:decoder])) {
         _username = [decoder decodeObjectOfClass:[NSString class] forKey:kUsername];
         _fullName = [decoder decodeObjectOfClass:[NSString class] forKey:kFullName];
         _profilePictureURL = [decoder decodeObjectOfClass:[NSString class] forKey:kProfilePictureURL];
@@ -87,6 +87,8 @@
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
+    [super encodeWithCoder:encoder];
+
     [encoder encodeObject:_username forKey:kUsername];
     [encoder encodeObject:_fullName forKey:kFullName];
     [encoder encodeObject:_profilePictureURL forKey:kProfilePictureURL];


### PR DESCRIPTION
I noticed that when coding/decoding `InstagramMedia` and `InstagramUser` objects that their `Id` property values were nil. Upon debugging, I realized that they simply weren't coding/decoding that property despite the superclass (`InstagramModel`) already doing that. This fixes it.