### PR TITLE
#72 Cocoapod Famework fix

### DIFF
--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -67,7 +67,7 @@
         self.httpManager = [[AFHTTPSessionManager alloc] initWithBaseURL:baseURL];
         self.httpManager.responseSerializer = [[AFJSONResponseSerializer alloc] init];
 
-        NSDictionary *info = [[NSBundle bundleForClass:[self class]] infoDictionary];
+        NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
         self.appClientID = info[kInstagramAppClientIdConfigurationKey];
         self.appRedirectURL = info[kInstagramAppRedirectURLConfigurationKey];
 


### PR DESCRIPTION
Resolves #72. Pod file setups that use 'use_frameworks!' should now work correctly.