### PR TITLE
Changed all Instagtam to Instagram

### DIFF
--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKCollectionViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKCollectionViewController.m
@@ -52,7 +52,7 @@
     [self loadMedia];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(userAuthenticationChanged:)
-                                                 name:InstagtamKitUserAuthenticationChangedNotification
+                                                 name:InstagramKitUserAuthenticationChangedNotification
                                                object:nil];
 }
 

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -82,7 +82,7 @@
         }
         
 #if INSTAGRAMKIT_UICKEYCHAINSTORE
-        self.keychainStore = [UICKeyChainStore keyChainStoreWithService:InstagtamKitKeychainStore];
+        self.keychainStore = [UICKeyChainStore keyChainStoreWithService:InstagramKitKeychainStore];
         _accessToken = self.keychainStore[@"token"];
 #endif
     }
@@ -125,7 +125,7 @@
     else
     {
         NSString *localizedDescription = NSLocalizedString(@"Authorization not granted.", @"Error notification to indicate Instagram OAuth token was not provided.");
-        *error = [NSError errorWithDomain:InstagtamKitErrorDomain
+        *error = [NSError errorWithDomain:InstagramKitErrorDomain
                                      code:InstagramKitAuthenticationFailedError
                                  userInfo:@{NSLocalizedDescriptionKey: localizedDescription}];
         success = NO;
@@ -162,7 +162,7 @@
     self.keychainStore[@"token"] = self.accessToken;
 #endif
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:InstagtamKitUserAuthenticationChangedNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:InstagramKitUserAuthenticationChangedNotification object:nil];
 }
 
 

--- a/InstagramKit/InstagramKitConstants.h
+++ b/InstagramKit/InstagramKitConstants.h
@@ -86,27 +86,27 @@ typedef NS_ENUM(NSUInteger, InstagramKitLoginScope)
 /*!
  @abstract      The notification posted on changing the authentication token.
  */
-INSTAGRAMKIT_EXTERN NSString *const InstagtamKitUserAuthenticationChangedNotification;
+INSTAGRAMKIT_EXTERN NSString *const InstagramKitUserAuthenticationChangedNotification;
 
 
 /*!
  @abstract      The error domain for all errors from InstagramKit.
  @discussion    Error codes in the range 0-99 are reserved for this domain.
  */
-INSTAGRAMKIT_EXTERN NSString *const InstagtamKitErrorDomain;
+INSTAGRAMKIT_EXTERN NSString *const InstagramKitErrorDomain;
 
 
 /*!
  @abstract      The Keychain Store service from InstagramKit to securely store credentials.
  */
-INSTAGRAMKIT_EXTERN NSString *const InstagtamKitKeychainStore;
+INSTAGRAMKIT_EXTERN NSString *const InstagramKitKeychainStore;
 
 
 /*!
- @typedef       NS_ENUM(NSInteger, InstagtamKitErrorCode)
- @abstract      Error codes for InstagtamKitErrorDomain.
+ @typedef       NS_ENUM(NSInteger, InstagramKitErrorCode)
+ @abstract      Error codes for InstagramKitErrorDomain.
  */
-typedef NS_ENUM(NSInteger, InstagtamKitErrorCode)
+typedef NS_ENUM(NSInteger, InstagramKitErrorCode)
 {
     /*!
      @abstract Reserved.

--- a/InstagramKit/InstagramKitConstants.m
+++ b/InstagramKit/InstagramKitConstants.m
@@ -28,9 +28,9 @@ NSString *const kInstagramKitAuthorizationURL = @"https://api.instagram.com/oaut
 NSString *const kInstagramAppClientIdConfigurationKey = @"InstagramAppClientId";
 NSString *const kInstagramAppRedirectURLConfigurationKey = @"InstagramAppRedirectURL";
 
-NSString *const InstagtamKitUserAuthenticationChangedNotification = @"com.instagramkit.token.change";
-NSString *const InstagtamKitErrorDomain = @"com.instagramkit";
-NSString *const InstagtamKitKeychainStore = @"com.instagramkit.secure";
+NSString *const InstagramKitUserAuthenticationChangedNotification = @"com.instagramkit.token.change";
+NSString *const InstagramKitErrorDomain = @"com.instagramkit";
+NSString *const InstagramKitKeychainStore = @"com.instagramkit.secure";
 
 NSString *const kKeyClientID = @"client_id";
 NSString *const kKeyAccessToken = @"access_token";


### PR DESCRIPTION
Was browsing the source code to figure out where the access token is saved to the keychain and stumbled upon this typo. Perhaps it is intentional but I'm guessing not.