### PR TITLE
Fix Token Get

### DIFF
--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -180,7 +180,7 @@ typedef enum
         return @"basic";
     }
     
-    return [strings componentsJoinedByString:@"+"];
+    return [strings componentsJoinedByString:@" "];
 }
 
 


### PR DESCRIPTION
Hi there! 
Can you consider to add this little fix for getting a multi permission token from Instagram?

The issue is that the "+" separator it get %scaped and Instagram service don't work to well with them.

Cheers!