### PR TITLE
Updated Scope from NS_ENUM to NS_OPTIONS

### DIFF
--- a/InstagramKit/InstagramKitConstants.h
+++ b/InstagramKit/InstagramKitConstants.h
@@ -70,7 +70,7 @@ INSTAGRAMKIT_EXTERN NSString *const kInstagramAppRedirectURLConfigurationKey;
  https://instagram.com/developer/authentication/#scope
  
  */
-typedef NS_ENUM(NSUInteger, InstagramKitLoginScope)
+typedef NS_OPTIONS(NSUInteger, InstagramKitLoginScope)
 {
     /*! Indicates permission to read data on a user’s behalf, e.g. recent media, following lists (granted by default) */
     InstagramKitLoginScopeBasic = 0,


### PR DESCRIPTION
Fixes #152
Allows Swift users to properly generate Authorisation Scope URL.

I tried to write tests for this change but couldn't get the tests running. Kept running up against an undefined symbol for AFNetworing classes when trying to compile for the test target. I did a manual test against the example project and it doesn't break existing implementations.