### PR TITLE
InstagramModel copyWithZone updated to allocate correct type of object.

### DIFF
--- a/InstagramKit/Models/InstagramModel.m
+++ b/InstagramKit/Models/InstagramModel.m
@@ -133,7 +133,7 @@ NSString *const kCursor = @"cursor";
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    InstagramModel *copy = [[InstagramModel allocWithZone:zone] init];
+    InstagramModel *copy = [[[self class] allocWithZone:zone] init];
     copy->_Id = [_Id copy];
     return copy;
 }


### PR DESCRIPTION
If you just allocate InstagramModel, it doesn't work for inherited classes.