### PR TITLE
Add Nullability and Lightweight Generics for Xcode 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: objective-c
 xcode_workspace: InstagramKit.xcworkspace
 xcode_scheme: InstagramKit
-osx_image: xcode6.4
+osx_image: xcode7
 xcode_sdk: iphonesimulator8.4
 # before_install:
 #     - pod repo remove master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: objective-c
 xcode_workspace: InstagramKit.xcworkspace
 xcode_scheme: InstagramKit
 osx_image: xcode7
-xcode_sdk: iphonesimulator8.4
+xcode_sdk: iphonesimulator9.0
 # before_install:
 #     - pod repo remove master
 #     - pod setup

--- a/InstagramKit/Engine/InstagramEngine.h
+++ b/InstagramKit/Engine/InstagramEngine.h
@@ -23,6 +23,8 @@
 #import <UIKit/UIKit.h>
 #import "InstagramKitConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface InstagramEngine : NSObject
 
 /*!
@@ -33,18 +35,18 @@
 /**
  *  Client Id of your App, as registered with Instagram.
  */
-@property (nonatomic, copy) NSString *appClientID;
+@property (nullable, nonatomic, copy) NSString *appClientID;
 
 /**
  *  Redirect URL of your App, as registered with Instagram.
  */
-@property (nonatomic, copy) NSString *appRedirectURL;
+@property (nullable, nonatomic, copy) NSString *appRedirectURL;
 
 /**
  *  The oauth token stored in the account store credential, if available.
  *  If not empty, this implies user has granted access.
  */
-@property (nonatomic, strong) NSString *accessToken;
+@property (nullable, nonatomic, strong) NSString *accessToken;
 
 
 #pragma mark - Authentication -
@@ -78,7 +80,7 @@
  *  @return YES if valid token extracted and saved, otherwise NO.
  */
 - (BOOL)receivedValidAccessTokenFromURL:(NSURL *)url
-                                  error:(NSError *__autoreleasing *)error;
+                                  error:(NSError * _Nullable __autoreleasing *)error;
 
 /**
  *  Validate if authorization is done.
@@ -103,8 +105,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getMedia:(NSString *)mediaId
-     withSuccess:(InstagramMediaObjectBlock)success
-         failure:(InstagramFailureBlock)failure;
+     withSuccess:(nullable InstagramMediaObjectBlock)success
+         failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -113,8 +115,8 @@
  *  @param success  Provides an array of Media objects and Pagination info.
  *  @param failure  Provides an error and a server status code.
  */
-- (void)getPopularMediaWithSuccess:(InstagramMediaBlock)success
-                           failure:(InstagramFailureBlock)failure;
+- (void)getPopularMediaWithSuccess:(nullable InstagramMediaBlock)success
+                           failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -129,8 +131,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getMediaAtLocation:(CLLocationCoordinate2D)location
-               withSuccess:(InstagramMediaBlock)success
-                   failure:(InstagramFailureBlock)failure;
+               withSuccess:(nullable InstagramMediaBlock)success
+                   failure:(nullable InstagramFailureBlock)failure;
 
 /**
  *  Search for media in a given area. The default time span is set to 5 days.
@@ -145,10 +147,10 @@
  */
 - (void)getMediaAtLocation:(CLLocationCoordinate2D)location
                      count:(NSInteger)count
-                     maxId:(NSString *)maxId
+                     maxId:(nullable NSString *)maxId
                   distance:(CGFloat)distance
-               withSuccess:(InstagramMediaBlock)success
-                   failure:(InstagramFailureBlock)failure;
+               withSuccess:(nullable InstagramMediaBlock)success
+                   failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Locations -
@@ -162,8 +164,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)searchLocationsAtLocation:(CLLocationCoordinate2D)loction
-                      withSuccess:(InstagramLocationsBlock)success
-                          failure:(InstagramFailureBlock)failure;
+                      withSuccess:(nullable InstagramLocationsBlock)success
+                          failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -176,8 +178,8 @@
  */
 - (void)searchLocationsAtLocation:(CLLocationCoordinate2D)loction
                  distanceInMeters:(NSInteger)distance
-                      withSuccess:(InstagramLocationsBlock)success
-                          failure:(InstagramFailureBlock)failure;
+                      withSuccess:(nullable InstagramLocationsBlock)success
+                          failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -188,8 +190,8 @@
  *  @param failure      Provides an error and a server status code.
  */
 - (void)getLocationWithId:(NSString*)locationId
-              withSuccess:(InstagramLocationBlock)success
-                  failure:(InstagramFailureBlock)failure;
+              withSuccess:(nullable InstagramLocationBlock)success
+                  failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -200,8 +202,8 @@
  *  @param failure      Provides an error and a server status code.
  */
 - (void)getMediaAtLocationWithId:(NSString*)locationId
-                     withSuccess:(InstagramMediaBlock)success
-                         failure:(InstagramFailureBlock)failure;
+                     withSuccess:(nullable InstagramMediaBlock)success
+                         failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Users -
@@ -215,8 +217,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getUserDetails:(NSString *)userId
-           withSuccess:(InstagramUserBlock)success
-               failure:(InstagramFailureBlock)failure;
+           withSuccess:(nullable InstagramUserBlock)success
+               failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -230,8 +232,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getMediaForUser:(NSString *)userId
-            withSuccess:(InstagramMediaBlock)success
-                failure:(InstagramFailureBlock)failure;
+            withSuccess:(nullable InstagramMediaBlock)success
+                failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -245,9 +247,9 @@
  */
 - (void)getMediaForUser:(NSString *)userId
                   count:(NSInteger)count
-                  maxId:(NSString *)maxId
-            withSuccess:(InstagramMediaBlock)success
-                failure:(InstagramFailureBlock)failure;
+                  maxId:(nullable NSString *)maxId
+            withSuccess:(nullable InstagramMediaBlock)success
+                failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -261,8 +263,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)searchUsersWithString:(NSString *)name
-                  withSuccess:(InstagramUsersBlock)success
-                      failure:(InstagramFailureBlock)failure;
+                  withSuccess:(nullable InstagramUsersBlock)success
+                      failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Self User -
@@ -274,8 +276,8 @@
  *  @param success  Provides an User object.
  *  @param failure  Provides an error and a server status code.
  */
-- (void)getSelfUserDetailsWithSuccess:(InstagramUserBlock)success
-                              failure:(InstagramFailureBlock)failure;
+- (void)getSelfUserDetailsWithSuccess:(nullable InstagramUserBlock)success
+                              failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -287,8 +289,8 @@
  *  @param success  Provides an array of Media objects and Pagination info.
  *  @param failure  Provides an error and a server status code.
  */
-- (void)getSelfFeedWithSuccess:(InstagramMediaBlock)success
-                       failure:(InstagramFailureBlock)failure;
+- (void)getSelfFeedWithSuccess:(nullable InstagramMediaBlock)success
+                       failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -300,9 +302,9 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getSelfFeedWithCount:(NSInteger)count
-                       maxId:(NSString *)maxId
-                     success:(InstagramMediaBlock)success
-                     failure:(InstagramFailureBlock)failure;
+                       maxId:(nullable NSString *)maxId
+                     success:(nullable InstagramMediaBlock)success
+                     failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -316,8 +318,8 @@
  *  @param success  Provides an array of Media objects and Pagination info.
  *  @param failure  Provides an error and a server status code.
  */
-- (void)getMediaLikedBySelfWithSuccess:(InstagramMediaBlock)success
-                               failure:(InstagramFailureBlock)failure;
+- (void)getMediaLikedBySelfWithSuccess:(nullable InstagramMediaBlock)success
+                               failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -331,9 +333,9 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getMediaLikedBySelfWithCount:(NSInteger)count
-                               maxId:(NSString *)maxId
-                             success:(InstagramMediaBlock)success
-                             failure:(InstagramFailureBlock)failure;
+                               maxId:(nullable NSString *)maxId
+                             success:(nullable InstagramMediaBlock)success
+                             failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -345,8 +347,8 @@
  *  @param success  Provides an array of Media objects and Pagination info.
  *  @param failure  Provides an error and a server status code.
  */
-- (void)getSelfRecentMediaWithSuccess:(InstagramMediaBlock)success
-                              failure:(InstagramFailureBlock)failure;
+- (void)getSelfRecentMediaWithSuccess:(nullable InstagramMediaBlock)success
+                              failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -358,9 +360,9 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getSelfRecentMediaWithCount:(NSInteger)count
-                              maxId:(NSString *)maxId
-                            success:(InstagramMediaBlock)success
-                            failure:(InstagramFailureBlock)failure;
+                              maxId:(nullable NSString *)maxId
+                            success:(nullable InstagramMediaBlock)success
+                            failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Tags -
@@ -374,8 +376,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getTagDetailsWithName:(NSString *)name
-                  withSuccess:(InstagramTagBlock)success
-                      failure:(InstagramFailureBlock)failure;
+                  withSuccess:(nullable InstagramTagBlock)success
+                      failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -389,8 +391,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getMediaWithTagName:(NSString *)name
-                withSuccess:(InstagramMediaBlock)success
-                    failure:(InstagramFailureBlock)failure;
+                withSuccess:(nullable InstagramMediaBlock)success
+                    failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -404,9 +406,9 @@
  */
 - (void)getMediaWithTagName:(NSString *)tag
                       count:(NSInteger)count
-                      maxId:(NSString *)maxId
-                withSuccess:(InstagramMediaBlock)success
-                    failure:(InstagramFailureBlock)failure;
+                      maxId:(nullable NSString *)maxId
+                withSuccess:(nullable InstagramMediaBlock)success
+                    failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark -
@@ -420,8 +422,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)searchTagsWithName:(NSString *)name
-               withSuccess:(InstagramTagsBlock)success
-                   failure:(InstagramFailureBlock)failure;
+               withSuccess:(nullable InstagramTagsBlock)success
+                   failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -435,9 +437,9 @@
  */
 - (void)searchTagsWithName:(NSString *)name
                      count:(NSInteger)count
-                     maxId:(NSString *)maxId
-               withSuccess:(InstagramTagsBlock)success
-                   failure:(InstagramFailureBlock)failure;
+                     maxId:(nullable NSString *)maxId
+               withSuccess:(nullable InstagramTagsBlock)success
+                   failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Comments -
@@ -451,8 +453,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getCommentsOnMedia:(NSString *)mediaId
-               withSuccess:(InstagramCommentsBlock)success
-                   failure:(InstagramFailureBlock)failure;
+               withSuccess:(nullable InstagramCommentsBlock)success
+                   failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -474,8 +476,8 @@
  */
 - (void)createComment:(NSString *)commentText
               onMedia:(NSString *)mediaId
-          withSuccess:(InstagramResponseBlock)success
-              failure:(InstagramFailureBlock)failure;
+          withSuccess:(nullable InstagramResponseBlock)success
+              failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -494,8 +496,8 @@
  */
 - (void)removeComment:(NSString *)commentId
               onMedia:(NSString *)mediaId
-          withSuccess:(InstagramResponseBlock)success
-              failure:(InstagramFailureBlock)failure;
+          withSuccess:(nullable InstagramResponseBlock)success
+              failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Likes -
@@ -509,8 +511,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getLikesOnMedia:(NSString *)mediaId
-            withSuccess:(InstagramUsersBlock)success
-                failure:(InstagramFailureBlock)failure;
+            withSuccess:(nullable InstagramUsersBlock)success
+                failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -525,8 +527,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)likeMedia:(NSString *)mediaId
-      withSuccess:(InstagramResponseBlock)success
-          failure:(InstagramFailureBlock)failure;
+      withSuccess:(nullable InstagramResponseBlock)success
+          failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -541,8 +543,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)unlikeMedia:(NSString *)mediaId
-        withSuccess:(InstagramResponseBlock)success
-            failure:(InstagramFailureBlock)failure;
+        withSuccess:(nullable InstagramResponseBlock)success
+            failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Relationships -
@@ -556,8 +558,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getRelationshipStatusOfUser:(NSString *)userId
-                        withSuccess:(InstagramResponseBlock)success
-                            failure:(InstagramFailureBlock)failure;
+                        withSuccess:(nullable InstagramResponseBlock)success
+                            failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -568,8 +570,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getUsersFollowedByUser:(NSString *)userId
-                   withSuccess:(InstagramUsersBlock)success
-                       failure:(InstagramFailureBlock)failure;
+                   withSuccess:(nullable InstagramUsersBlock)success
+                       failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -580,8 +582,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)getFollowersOfUser:(NSString *)userId
-               withSuccess:(InstagramUsersBlock)success
-                   failure:(InstagramFailureBlock)failure;
+               withSuccess:(nullable InstagramUsersBlock)success
+                   failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -590,8 +592,8 @@
  *  @param success  Provides an array of User objects and Pagination info.
  *  @param failure  Provides an error and a server status code.
  */
-- (void)getFollowRequestsWithSuccess:(InstagramUsersBlock)success
-                             failure:(InstagramFailureBlock)failure;
+- (void)getFollowRequestsWithSuccess:(nullable InstagramUsersBlock)success
+                             failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -608,8 +610,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)followUser:(NSString *)userId
-       withSuccess:(InstagramResponseBlock)success
-           failure:(InstagramFailureBlock)failure;
+       withSuccess:(nullable InstagramResponseBlock)success
+           failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -626,8 +628,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)unfollowUser:(NSString *)userId
-         withSuccess:(InstagramResponseBlock)success
-             failure:(InstagramFailureBlock)failure;
+         withSuccess:(nullable InstagramResponseBlock)success
+             failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -644,8 +646,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)blockUser:(NSString *)userId
-      withSuccess:(InstagramResponseBlock)success
-          failure:(InstagramFailureBlock)failure;
+      withSuccess:(nullable InstagramResponseBlock)success
+          failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -662,8 +664,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)unblockUser:(NSString *)userId
-        withSuccess:(InstagramResponseBlock)success
-            failure:(InstagramFailureBlock)failure;
+        withSuccess:(nullable InstagramResponseBlock)success
+            failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -680,8 +682,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)approveUser:(NSString *)userId
-        withSuccess:(InstagramResponseBlock)success
-            failure:(InstagramFailureBlock)failure;
+        withSuccess:(nullable InstagramResponseBlock)success
+            failure:(nullable InstagramFailureBlock)failure;
 
 
 /**
@@ -698,8 +700,8 @@
  *  @param failure  Provides an error and a server status code.
  */
 - (void)ignoreUser:(NSString *)userId
-     withSuccess:(InstagramResponseBlock)success
-         failure:(InstagramFailureBlock)failure;
+     withSuccess:(nullable InstagramResponseBlock)success
+         failure:(nullable InstagramFailureBlock)failure;
 
 
 #pragma mark - Common Pagination Request -
@@ -713,8 +715,10 @@
  *  @param failure        Provides an error and a server status code.
  */
 - (void)getPaginatedItemsForInfo:(InstagramPaginationInfo *)paginationInfo
-                     withSuccess:(InstagramPaginatiedResponseBlock)success
-                         failure:(InstagramFailureBlock)failure;
+                     withSuccess:(nullable InstagramPaginatiedResponseBlock)success
+                         failure:(nullable InstagramFailureBlock)failure;
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/InstagramKitConstants.h
+++ b/InstagramKit/InstagramKitConstants.h
@@ -127,6 +127,7 @@ typedef NS_ENUM(NSInteger, InstagramKitErrorCode)
 
 @class InstagramUser;
 @class InstagramMedia;
+@class InstagramComment;
 @class InstagramPaginationInfo;
 @class InstagramTag;
 @class InstagramLocation;
@@ -138,14 +139,14 @@ typedef NS_ENUM(NSInteger, InstagramKitErrorCode)
  *  @param paginatedObjects Array of Instagram model objects.
  *  @param paginationInfo   A PaginationInfo object.
  */
-typedef void (^InstagramPaginatiedResponseBlock)(NSArray *paginatedObjects, InstagramPaginationInfo *paginationInfo);
+typedef void (^InstagramPaginatiedResponseBlock)(NSArray<InstagramModel *> *paginatedObjects, InstagramPaginationInfo *paginationInfo);
 
 /**
  *  A generic block used as a callback for receiving a single object.
  *
  *  @param model    An Instagram model object.
  */
-typedef void (^InstagramObjectBlock)(id object);
+typedef void (^InstagramObjectBlock)(__kindof InstagramModel *object);
 
 /**
  *  A callback block providing a collection of Media objects.
@@ -153,7 +154,7 @@ typedef void (^InstagramObjectBlock)(id object);
  *  @param media            An array of InstagramMedia objects.
  *  @param paginationInfo   A PaginationInfo object.
  */
-typedef void (^InstagramMediaBlock)(NSArray *media, InstagramPaginationInfo *paginationInfo);
+typedef void (^InstagramMediaBlock)(NSArray<InstagramMedia *> *media, InstagramPaginationInfo *paginationInfo);
 
 /**
  *  A callback block providing a collection of User objects.
@@ -161,7 +162,7 @@ typedef void (^InstagramMediaBlock)(NSArray *media, InstagramPaginationInfo *pag
  *  @param users            An array of User objects.
  *  @param paginationInfo   A PaginationInfo object.
  */
-typedef void (^InstagramUsersBlock)(NSArray *users, InstagramPaginationInfo *paginationInfo);
+typedef void (^InstagramUsersBlock)(NSArray<InstagramUser *> *users, InstagramPaginationInfo *paginationInfo);
 
 /**
  *  A callback block providing a collection of Location objects.
@@ -169,7 +170,7 @@ typedef void (^InstagramUsersBlock)(NSArray *users, InstagramPaginationInfo *pag
  *  @param locations        An array of InstagramLocation objects.
  *  @param paginationInfo   A PaginationInfo object.
  */
-typedef void (^InstagramLocationsBlock)(NSArray *locations, InstagramPaginationInfo *paginationInfo);
+typedef void (^InstagramLocationsBlock)(NSArray<InstagramLocation *> *locations, InstagramPaginationInfo *paginationInfo);
 
 /**
  *  A callback block providing a collection of Comment objects.
@@ -177,7 +178,7 @@ typedef void (^InstagramLocationsBlock)(NSArray *locations, InstagramPaginationI
  *  @param comments         An array of InstagramComment objects.
  *  @param paginationInfo   A PaginationInfo object.
  */
-typedef void (^InstagramCommentsBlock)(NSArray *comments, InstagramPaginationInfo *paginationInfo);
+typedef void (^InstagramCommentsBlock)(NSArray<InstagramComment *> *comments, InstagramPaginationInfo *paginationInfo);
 
 /**
  *  A callback block providing a collection of Tag objects.
@@ -185,7 +186,7 @@ typedef void (^InstagramCommentsBlock)(NSArray *comments, InstagramPaginationInf
  *  @param tags             An array of Tag objects.
  *  @param paginationInfo   A PaginationInfo object.
  */
-typedef void (^InstagramTagsBlock)(NSArray *tags, InstagramPaginationInfo *paginationInfo);
+typedef void (^InstagramTagsBlock)(NSArray<InstagramTag *> *tags, InstagramPaginationInfo *paginationInfo);
 
 /**
  *  A callback block providing a User object.

--- a/InstagramKit/InstagramKitConstants.h
+++ b/InstagramKit/InstagramKitConstants.h
@@ -20,6 +20,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 #define INSTAGRAMKIT_EXTERN extern "C" __attribute__((visibility ("default")))
 #else
@@ -269,3 +271,5 @@ INSTAGRAMKIT_EXTERN NSString *const kRelationshipActionIgnore;
 #define IKValidArray(array) (IKNotNull(array) && [array isKindOfClass:[NSArray class]])
 #define IKValidString(str) (IKNotNull(str) && [str isKindOfClass:[NSString class]])
 #define IKValidNumber(num) (IKNotNull(num) && [num isKindOfClass:[NSNumber class]])
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/InstagramKitConstants.h
+++ b/InstagramKit/InstagramKitConstants.h
@@ -146,7 +146,7 @@ typedef void (^InstagramPaginatiedResponseBlock)(NSArray<InstagramModel *> *pagi
  *
  *  @param model    An Instagram model object.
  */
-typedef void (^InstagramObjectBlock)(__kindof InstagramModel *object);
+typedef void (^InstagramObjectBlock)(id object);
 
 /**
  *  A callback block providing a collection of Media objects.

--- a/InstagramKit/Models/InstagramComment.h
+++ b/InstagramKit/Models/InstagramComment.h
@@ -21,6 +21,8 @@
 #import <Foundation/Foundation.h>
 #import "InstagramModel.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class InstagramUser;
 
 @interface InstagramComment : InstagramModel <NSCopying, NSSecureCoding, NSObject>
@@ -47,3 +49,5 @@
 - (BOOL)isEqualToComment:(InstagramComment *)comment;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/Models/InstagramLocation.h
+++ b/InstagramKit/Models/InstagramLocation.h
@@ -22,6 +22,8 @@
 #import "InstagramModel.h"
 #import <MapKit/MapKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface InstagramLocation : InstagramModel <NSCopying, NSSecureCoding, NSObject>
 
 /**
@@ -42,3 +44,5 @@
 - (BOOL)isEqualToLocation:(InstagramLocation *)location;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/Models/InstagramMedia.h
+++ b/InstagramKit/Models/InstagramMedia.h
@@ -23,6 +23,8 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import "InstagramModel.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class InstagramUser;
 @class InstagramComment;
 @class InstagramLocation;
@@ -52,7 +54,7 @@
 /**
  *  Caption created by creator of the Media.
  */
-@property (nonatomic, readonly) InstagramComment* caption;
+@property (nullable, nonatomic, readonly) InstagramComment* caption;
 
 /**
  *  Number of likes on the Media.
@@ -62,7 +64,7 @@
 /**
  *  List of users who have liked the Media.
  */
-@property (nonatomic, readonly) NSArray *likes;
+@property (nonatomic, readonly) NSArray<InstagramUser *> *likes;
 
 /**
  *  Number of comments on the Media.
@@ -72,12 +74,12 @@
 /**
  *  An array of comments on the Media.
  */
-@property (nonatomic, readonly) NSArray *comments;
+@property (nonatomic, readonly) NSArray<InstagramComment *> *comments;
 
 /**
  *  Tags on the Media.
  */
-@property (nonatomic, readonly) NSArray *tags;
+@property (nonatomic, readonly) NSArray<InstagramTag *> *tags;
 
 /**
  *  Media Location coordinates
@@ -87,17 +89,17 @@
 /**
  *  Media Location id.
  */
-@property (nonatomic, readonly) NSString *locationId;
+@property (nullable, nonatomic, readonly) NSString *locationId;
 
 /**
  *  Media Location name.
  */
-@property (nonatomic, readonly) NSString *locationName;
+@property (nullable, nonatomic, readonly) NSString *locationName;
 
 /**
  *  Filter applied on Media during creation.
  */
-@property (nonatomic, readonly) NSString *filter;
+@property (nullable, nonatomic, readonly) NSString *filter;
 
 /**
  *  Link to the thumbnail image of the Media.
@@ -137,7 +139,7 @@
 /**
  *  Link to the low resolution video of the Media, if Media is a video.
  */
-@property (nonatomic, readonly) NSURL *lowResolutionVideoURL;
+@property (nullable, nonatomic, readonly) NSURL *lowResolutionVideoURL;
 
 /**
  *  Size of the low resolution video frame.
@@ -147,7 +149,7 @@
 /**
  *  Link to the standard resolution video of the Media, if Media is a video.
  */
-@property (nonatomic, readonly) NSURL *standardResolutionVideoURL;
+@property (nullable, nonatomic, readonly) NSURL *standardResolutionVideoURL;
 
 /**
  *  Size of the standard resolution video frame.
@@ -162,3 +164,5 @@
 - (BOOL)isEqualToMedia:(InstagramMedia *)media;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/Models/InstagramModel.h
+++ b/InstagramKit/Models/InstagramModel.h
@@ -21,6 +21,8 @@
 #import <Foundation/Foundation.h>
 #import "InstagramKitConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  JSON keys as string constants.
  */
@@ -97,3 +99,4 @@ INSTAGRAMKIT_EXTERN NSString *const kLocationName;
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/Models/InstagramPaginationInfo.h
+++ b/InstagramKit/Models/InstagramPaginationInfo.h
@@ -20,6 +20,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface InstagramPaginationInfo : NSObject <NSCopying, NSSecureCoding, NSObject>
 
 /**
@@ -53,3 +55,5 @@
 - (BOOL)isEqualToPaginationInfo:(InstagramPaginationInfo *)paginationInfo;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/Models/InstagramTag.h
+++ b/InstagramKit/Models/InstagramTag.h
@@ -21,6 +21,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface InstagramTag : NSObject <NSCopying, NSSecureCoding, NSObject>
 
 /**
@@ -41,3 +43,5 @@
 - (BOOL)isEqualToTag:(InstagramTag *)tag;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/InstagramKit/Models/InstagramUser.h
+++ b/InstagramKit/Models/InstagramUser.h
@@ -22,6 +22,8 @@
 
 #import "InstagramModel.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface InstagramUser : InstagramModel <NSCopying, NSSecureCoding, NSObject>
 
 /**
@@ -32,22 +34,22 @@
 /**
  *  User's full name.
  */
-@property (readonly) NSString* fullName;
+@property (nullable, readonly) NSString* fullName;
 
 /**
  *  Link to the User's profile picture.
  */
-@property (readonly) NSURL* profilePictureURL;
+@property (nullable, readonly) NSURL* profilePictureURL;
 
 /**
  *  User's short bio, if provided.
  */
-@property (readonly) NSString* bio;
+@property (nullable, readonly) NSString* bio;
 
 /**
  *  User's website, if provided.
  */
-@property (readonly) NSURL* website;
+@property (nullable, readonly) NSURL* website;
 
 /**
  *  Number of Media uploaded by the User.
@@ -81,3 +83,5 @@
 - (BOOL)isEqualToUser:(InstagramUser *)user;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This makes the framework much nicer for use in Swift. Not sure if `error` in the failure block type should be nullable.