### PR TITLE
Update + new functionalities for InstagramKit-Example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ All notable changes to this project will be documented in this file.
 **on `dev` branch**
 
 - Support for Instagram Platform updates - http://developers.instagram.com/post/133424514006/instagram-platform-update 
+- [#201](https://github.com/shyambhat/InstagramKit/pull/201) Solved issue [#194](https://github.com/shyambhat/InstagramKit/pull/194): New Permissions For Instagram. By [@zzdjk6](https://github.com/zzdjk6)
 
 ## [3.7] - 2015-12-09
 - Complete Swift compatibility.
-- #179 Add Nullability and Lightweight Generics for Xcode 7. By @Adlai-Holler
-- Unit tests for Media and User methods in InstagramEngine. By @shyambhat
-- #177 Fix issue with pagination. Avoid percent-encoding twice. By @snoonz
+- [#179](https://github.com/shyambhat/InstagramKit/pull/179) Add Nullability and Lightweight Generics for Xcode 7. By [@Adlai-Holler](https://github.com/Adlai-Holler)
+- Unit tests for Media and User methods in InstagramEngine. By [@shyambhat](https://github.com/shyambhat)
+- [#177](https://github.com/shyambhat/InstagramKit/pull/177) Fix issue with pagination. Avoid percent-encoding twice. By [@snoonz](https://github.com/snoonz)
 
 #### Added
 - #188 ```InstagramUser loadDetailsWithCompletion:``` to fetch User details and update the same user object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Support for Instagram Platform updates - http://developers.instagram.com/post/133424514006/instagram-platform-update 
 - [#201](https://github.com/shyambhat/InstagramKit/pull/201) Solved issue [#194](https://github.com/shyambhat/InstagramKit/pull/194): New Permissions For Instagram. By [@zzdjk6](https://github.com/zzdjk6)
+- [#204](https://github.com/shyambhat/InstagramKit/pull/204) Support for AFNetworking 3.0 By [@shyambhat](https://github.com/shyambhat)
 
 ## [3.7] - 2015-12-09
 - Complete Swift compatibility.

--- a/InstagramKit-Example/InstagramKit-Example.xcodeproj/project.pbxproj
+++ b/InstagramKit-Example/InstagramKit-Example.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4982C90C1C98693300D618E0 /* IKSearchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4982C90B1C98693300D618E0 /* IKSearchViewController.m */; };
 		4982C9161C986BB900D618E0 /* IKCollectionCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4982C9151C986BB900D618E0 /* IKCollectionCell.m */; };
 		4982C9191C98767500D618E0 /* IKSearchTagCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4982C9181C98767500D618E0 /* IKSearchTagCell.m */; };
+		49CC76451C991A9400C39781 /* IKSearchCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49CC76441C991A9400C39781 /* IKSearchCollectionViewController.m */; };
 		49EDCD7A1C98B42F005A9BB6 /* IKSearchUserCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EDCD791C98B42F005A9BB6 /* IKSearchUserCell.m */; };
 		82DA95051B483C1C00A6303B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DA95041B483C1C00A6303B /* main.m */; };
 		82DA950E1B483C1C00A6303B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 82DA950C1B483C1C00A6303B /* Main.storyboard */; };
@@ -30,6 +31,8 @@
 		4982C9151C986BB900D618E0 /* IKCollectionCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKCollectionCell.m; sourceTree = "<group>"; };
 		4982C9171C98767500D618E0 /* IKSearchTagCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IKSearchTagCell.h; path = "SearchView Cells/IKSearchTagCell.h"; sourceTree = "<group>"; };
 		4982C9181C98767500D618E0 /* IKSearchTagCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = IKSearchTagCell.m; path = "SearchView Cells/IKSearchTagCell.m"; sourceTree = "<group>"; };
+		49CC76431C991A9400C39781 /* IKSearchCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IKSearchCollectionViewController.h; sourceTree = "<group>"; };
+		49CC76441C991A9400C39781 /* IKSearchCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKSearchCollectionViewController.m; sourceTree = "<group>"; };
 		49EDCD781C98B42F005A9BB6 /* IKSearchUserCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IKSearchUserCell.h; path = "SearchView Cells/IKSearchUserCell.h"; sourceTree = "<group>"; };
 		49EDCD791C98B42F005A9BB6 /* IKSearchUserCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = IKSearchUserCell.m; path = "SearchView Cells/IKSearchUserCell.m"; sourceTree = "<group>"; };
 		82DA94FF1B483C1C00A6303B /* InstagramKit-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "InstagramKit-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -133,6 +136,8 @@
 				82DA95361B483CA900A6303B /* IKMediaViewController.m */,
 				4982C90A1C98693300D618E0 /* IKSearchViewController.h */,
 				4982C90B1C98693300D618E0 /* IKSearchViewController.m */,
+				49CC76431C991A9400C39781 /* IKSearchCollectionViewController.h */,
+				49CC76441C991A9400C39781 /* IKSearchCollectionViewController.m */,
 				82DA95441B48509100A6303B /* CollectionView Cells */,
 				4982C9101C986B1F00D618E0 /* SearchView Cells */,
 			);
@@ -292,6 +297,7 @@
 				4982C9191C98767500D618E0 /* IKSearchTagCell.m in Sources */,
 				49EDCD7A1C98B42F005A9BB6 /* IKSearchUserCell.m in Sources */,
 				4982C9161C986BB900D618E0 /* IKCollectionCell.m in Sources */,
+				49CC76451C991A9400C39781 /* IKSearchCollectionViewController.m in Sources */,
 				82DA953C1B483CA900A6303B /* IKMediaViewController.m in Sources */,
 				82DA953A1B483CA900A6303B /* IKCollectionViewController.m in Sources */,
 				4982C90C1C98693300D618E0 /* IKSearchViewController.m in Sources */,

--- a/InstagramKit-Example/InstagramKit-Example.xcodeproj/project.pbxproj
+++ b/InstagramKit-Example/InstagramKit-Example.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4982C90C1C98693300D618E0 /* IKSearchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4982C90B1C98693300D618E0 /* IKSearchViewController.m */; };
+		4982C9161C986BB900D618E0 /* IKCollectionCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4982C9151C986BB900D618E0 /* IKCollectionCell.m */; };
+		4982C9191C98767500D618E0 /* IKSearchTagCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4982C9181C98767500D618E0 /* IKSearchTagCell.m */; };
+		49EDCD7A1C98B42F005A9BB6 /* IKSearchUserCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EDCD791C98B42F005A9BB6 /* IKSearchUserCell.m */; };
 		82DA95051B483C1C00A6303B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DA95041B483C1C00A6303B /* main.m */; };
 		82DA950E1B483C1C00A6303B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 82DA950C1B483C1C00A6303B /* Main.storyboard */; };
 		82DA95101B483C1C00A6303B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82DA950F1B483C1C00A6303B /* Images.xcassets */; };
@@ -15,12 +19,19 @@
 		82DA953A1B483CA900A6303B /* IKCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DA95321B483CA900A6303B /* IKCollectionViewController.m */; };
 		82DA953B1B483CA900A6303B /* IKLoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DA95341B483CA900A6303B /* IKLoginViewController.m */; };
 		82DA953C1B483CA900A6303B /* IKMediaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DA95361B483CA900A6303B /* IKMediaViewController.m */; };
-		82DA95491B48509100A6303B /* IKCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DA95461B48509100A6303B /* IKCell.m */; };
 		A500BB11472D0AEF43EE0940 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3E2BF4EAAF2BFE20E11B166 /* libPods.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		17B839D94B3A182F8D8DBFBE /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		4982C90A1C98693300D618E0 /* IKSearchViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IKSearchViewController.h; sourceTree = "<group>"; };
+		4982C90B1C98693300D618E0 /* IKSearchViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKSearchViewController.m; sourceTree = "<group>"; };
+		4982C9141C986BB900D618E0 /* IKCollectionCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IKCollectionCell.h; sourceTree = "<group>"; };
+		4982C9151C986BB900D618E0 /* IKCollectionCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKCollectionCell.m; sourceTree = "<group>"; };
+		4982C9171C98767500D618E0 /* IKSearchTagCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IKSearchTagCell.h; path = "SearchView Cells/IKSearchTagCell.h"; sourceTree = "<group>"; };
+		4982C9181C98767500D618E0 /* IKSearchTagCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = IKSearchTagCell.m; path = "SearchView Cells/IKSearchTagCell.m"; sourceTree = "<group>"; };
+		49EDCD781C98B42F005A9BB6 /* IKSearchUserCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IKSearchUserCell.h; path = "SearchView Cells/IKSearchUserCell.h"; sourceTree = "<group>"; };
+		49EDCD791C98B42F005A9BB6 /* IKSearchUserCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = IKSearchUserCell.m; path = "SearchView Cells/IKSearchUserCell.m"; sourceTree = "<group>"; };
 		82DA94FF1B483C1C00A6303B /* InstagramKit-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "InstagramKit-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		82DA95031B483C1C00A6303B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82DA95041B483C1C00A6303B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -35,8 +46,6 @@
 		82DA95341B483CA900A6303B /* IKLoginViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKLoginViewController.m; sourceTree = "<group>"; };
 		82DA95351B483CA900A6303B /* IKMediaViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IKMediaViewController.h; sourceTree = "<group>"; };
 		82DA95361B483CA900A6303B /* IKMediaViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKMediaViewController.m; sourceTree = "<group>"; };
-		82DA95451B48509100A6303B /* IKCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IKCell.h; sourceTree = "<group>"; };
-		82DA95461B48509100A6303B /* IKCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IKCell.m; sourceTree = "<group>"; };
 		C3E2BF4EAAF2BFE20E11B166 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB0EDA4E9C0E4C7F0DCD9E8C /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -53,6 +62,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4982C9101C986B1F00D618E0 /* SearchView Cells */ = {
+			isa = PBXGroup;
+			children = (
+				49EDCD781C98B42F005A9BB6 /* IKSearchUserCell.h */,
+				49EDCD791C98B42F005A9BB6 /* IKSearchUserCell.m */,
+				4982C9171C98767500D618E0 /* IKSearchTagCell.h */,
+				4982C9181C98767500D618E0 /* IKSearchTagCell.m */,
+			);
+			name = "SearchView Cells";
+			sourceTree = "<group>";
+		};
 		82DA94F61B483C1C00A6303B = {
 			isa = PBXGroup;
 			children = (
@@ -111,7 +131,10 @@
 				82DA95341B483CA900A6303B /* IKLoginViewController.m */,
 				82DA95351B483CA900A6303B /* IKMediaViewController.h */,
 				82DA95361B483CA900A6303B /* IKMediaViewController.m */,
+				4982C90A1C98693300D618E0 /* IKSearchViewController.h */,
+				4982C90B1C98693300D618E0 /* IKSearchViewController.m */,
 				82DA95441B48509100A6303B /* CollectionView Cells */,
+				4982C9101C986B1F00D618E0 /* SearchView Cells */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -119,8 +142,8 @@
 		82DA95441B48509100A6303B /* CollectionView Cells */ = {
 			isa = PBXGroup;
 			children = (
-				82DA95451B48509100A6303B /* IKCell.h */,
-				82DA95461B48509100A6303B /* IKCell.m */,
+				4982C9141C986BB900D618E0 /* IKCollectionCell.h */,
+				4982C9151C986BB900D618E0 /* IKCollectionCell.m */,
 			);
 			path = "CollectionView Cells";
 			sourceTree = "<group>";
@@ -266,9 +289,12 @@
 				82DA95371B483CA900A6303B /* AppDelegate.m in Sources */,
 				82DA95051B483C1C00A6303B /* main.m in Sources */,
 				82DA953B1B483CA900A6303B /* IKLoginViewController.m in Sources */,
+				4982C9191C98767500D618E0 /* IKSearchTagCell.m in Sources */,
+				49EDCD7A1C98B42F005A9BB6 /* IKSearchUserCell.m in Sources */,
+				4982C9161C986BB900D618E0 /* IKCollectionCell.m in Sources */,
 				82DA953C1B483CA900A6303B /* IKMediaViewController.m in Sources */,
 				82DA953A1B483CA900A6303B /* IKCollectionViewController.m in Sources */,
-				82DA95491B48509100A6303B /* IKCell.m in Sources */,
+				4982C90C1C98693300D618E0 /* IKSearchViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/InstagramKit-Example/InstagramKit-Example.xcodeproj/xcshareddata/xcschemes/InstagramKit-Example.xcscheme
+++ b/InstagramKit-Example/InstagramKit-Example.xcodeproj/xcshareddata/xcschemes/InstagramKit-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/InstagramKit-Example/InstagramKit-Example/Base.lproj/LaunchScreen.xib
+++ b/InstagramKit-Example/InstagramKit-Example/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>

--- a/InstagramKit-Example/InstagramKit-Example/Base.lproj/Main.storyboard
+++ b/InstagramKit-Example/InstagramKit-Example/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="lv9-3E-qvv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="lv9-3E-qvv">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
         <!--Collection View Controller-->
@@ -14,7 +15,6 @@
                     <collectionView key="view" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" minimumZoomScale="0.0" maximumZoomScale="0.0" dataMode="prototypes" id="Deh-zO-I04">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="iY8-CG-v3c">
                             <size key="itemSize" width="106" height="106"/>
@@ -23,7 +23,7 @@
                             <inset key="sectionInset" minX="1" minY="0.0" maxX="1" maxY="0.0"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CPCELL" id="QdO-6j-Fvb" customClass="IKCell">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CPCELL" id="QdO-6j-Fvb" customClass="IKCollectionCell">
                                 <rect key="frame" x="1" y="64" width="106" height="106"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -32,14 +32,11 @@
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="M44-nY-AWF">
                                             <rect key="frame" x="0.0" y="0.0" width="106" height="106"/>
-                                            <animations/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </imageView>
                                     </subviews>
-                                    <animations/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
-                                <animations/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstItem="M44-nY-AWF" firstAttribute="leading" secondItem="QdO-6j-Fvb" secondAttribute="leading" id="b4Z-8f-8JP"/>
@@ -65,16 +62,104 @@
                                 <action selector="loginTapped:" destination="4al-wR-gxx" id="6xZ-Bf-YC3"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" enabled="NO" title="More" id="3Nd-Tj-wLc">
-                            <connections>
-                                <action selector="moreTapped:" destination="4al-wR-gxx" id="8MH-dz-aIL"/>
-                            </connections>
-                        </barButtonItem>
+                        <rightBarButtonItems>
+                            <barButtonItem enabled="NO" title="More" id="3Nd-Tj-wLc">
+                                <connections>
+                                    <action selector="moreTapped:" destination="4al-wR-gxx" id="8MH-dz-aIL"/>
+                                </connections>
+                            </barButtonItem>
+                            <barButtonItem systemItem="search" id="eWR-Gw-LV2">
+                                <connections>
+                                    <segue destination="3fm-DV-8DE" kind="push" animates="NO" id="b9L-31-Eo1"/>
+                                </connections>
+                            </barButtonItem>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="p2i-vK-IcB" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="422" y="104"/>
+        </scene>
+        <!--Search-->
+        <scene sceneID="CYQ-T3-Nlo">
+            <objects>
+                <tableViewController id="3fm-DV-8DE" customClass="IKSearchViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="a57-lT-Kmh">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <searchBar key="tableHeaderView" contentMode="redraw" searchBarStyle="minimal" placeholder="@username or #tag" id="8ng-ow-c7c">
+                            <rect key="frame" x="0.0" y="64" width="320" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textInputTraits key="textInputTraits" keyboardType="twitter"/>
+                            <connections>
+                                <outlet property="delegate" destination="3fm-DV-8DE" id="CBc-Wl-LHi"/>
+                            </connections>
+                        </searchBar>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="searchUserCell" rowHeight="60" id="OHt-4Q-Vtw" customClass="IKSearchUserCell">
+                                <rect key="frame" x="0.0" y="136" width="320" height="60"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="OHt-4Q-Vtw" id="MhT-2s-DTM">
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="59"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uCw-Eq-0ot">
+                                            <rect key="frame" x="8" y="8" width="43" height="43"/>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GnB-Sd-GfY">
+                                            <rect key="frame" x="59" y="19" width="228" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="imageViewUser" destination="uCw-Eq-0ot" id="GfN-Ja-Drz"/>
+                                    <outlet property="labelUsername" destination="GnB-Sd-GfY" id="RuH-KL-BhK"/>
+                                </connections>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="searchTagCell" id="FOQ-Ox-79B" customClass="IKSearchTagCell">
+                                <rect key="frame" x="0.0" y="196" width="320" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FOQ-Ox-79B" id="21o-7c-QuN">
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Tag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lp4-Y1-X7o">
+                                            <rect key="frame" x="8" y="11" width="183" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fcx-Ik-Wos">
+                                            <rect key="frame" x="199" y="11" width="88" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="labelMediaCount" destination="fcx-Ik-Wos" id="ZNZ-dk-wkZ"/>
+                                    <outlet property="labelTag" destination="lp4-Y1-X7o" id="QHH-Zh-uFG"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="3fm-DV-8DE" id="1Hs-Nf-Vjo"/>
+                            <outlet property="delegate" destination="3fm-DV-8DE" id="l1y-NA-kzJ"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Search" id="LtK-8L-QYy"/>
+                    <connections>
+                        <outlet property="searchBar" destination="8ng-ow-c7c" id="q09-Ps-u0l"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="gby-HI-TVl" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="422" y="895"/>
         </scene>
         <!--Media View Controller-->
         <scene sceneID="i2X-FZ-KL9">
@@ -88,25 +173,22 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eeS-M5-Zb8">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eeS-M5-Zb8">
                                 <rect key="frame" x="8" y="72" width="304" height="304"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="eeS-M5-Zb8" secondAttribute="height" multiplier="1:1" id="pNG-dl-Jup"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Caption" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" preferredMaxLayoutWidth="304" translatesAutoresizingMaskIntoConstraints="NO" id="fcw-9R-yvC">
-                                <rect key="frame" x="8" y="384" width="304" height="70"/>
-                                <animations/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Caption" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" preferredMaxLayoutWidth="304" translatesAutoresizingMaskIntoConstraints="NO" id="fcw-9R-yvC">
+                                <rect key="frame" x="8" y="384" width="304" height="120"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="70" id="PBf-ts-yLW"/>
+                                    <constraint firstAttribute="height" constant="120" id="PBf-ts-yLW"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="eeS-M5-Zb8" firstAttribute="width" secondItem="fcw-9R-yvC" secondAttribute="width" id="8WU-vY-Cug"/>
@@ -142,14 +224,12 @@
                         <subviews>
                             <webView clipsSubviews="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="bBm-kX-gC1">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <animations/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <connections>
                                     <outlet property="delegate" destination="Qfj-6N-R6z" id="GUP-h4-CjV"/>
                                 </connections>
                             </webView>
                         </subviews>
-                        <animations/>
                         <constraints>
                             <constraint firstItem="xL7-Gk-126" firstAttribute="top" secondItem="bBm-kX-gC1" secondAttribute="bottom" id="1Vy-rU-t2G"/>
                             <constraint firstAttribute="trailing" secondItem="bBm-kX-gC1" secondAttribute="trailing" id="5ym-Qs-0aA"/>
@@ -161,24 +241,12 @@
                             <constraint firstItem="xL7-Gk-126" firstAttribute="top" secondItem="bBm-kX-gC1" secondAttribute="bottom" id="zDW-rM-vzb"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Login " id="tLF-sk-vbt">
-                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="y5t-aw-c8c">
-                            <connections>
-                                <segue destination="bg8-FQ-jcr" kind="unwind" unwindAction="unwindSegue:" id="bs6-0C-g4M"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="Done" id="miF-uD-4yD">
-                            <connections>
-                                <segue destination="bg8-FQ-jcr" kind="unwind" unwindAction="unwindSegue:" id="Qcu-EH-w5a"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Login " id="tLF-sk-vbt"/>
                     <connections>
                         <outlet property="webView" destination="bBm-kX-gC1" id="jm6-gY-iFs"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aGH-ev-YqG" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="bg8-FQ-jcr" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="1245" y="-565"/>
         </scene>
@@ -190,7 +258,6 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="vRl-vr-VAW">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -210,7 +277,6 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ER9-XT-p8R">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/InstagramKit-Example/InstagramKit-Example/Base.lproj/Main.storyboard
+++ b/InstagramKit-Example/InstagramKit-Example/Base.lproj/Main.storyboard
@@ -5,6 +5,7 @@
         <development version="5100" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
@@ -57,9 +58,9 @@
                     </collectionView>
                     <navigationItem key="navigationItem" id="OeR-Ef-F2w">
                         <nil key="title"/>
-                        <barButtonItem key="leftBarButtonItem" title="Log in" id="9wq-oD-noP" userLabel="Login">
+                        <barButtonItem key="leftBarButtonItem" title="Log out" id="9wq-oD-noP" userLabel="Logout">
                             <connections>
-                                <action selector="loginTapped:" destination="4al-wR-gxx" id="6xZ-Bf-YC3"/>
+                                <action selector="logoutTapped:" destination="4al-wR-gxx" id="i5h-Qu-7Nh"/>
                             </connections>
                         </barButtonItem>
                         <rightBarButtonItems>
@@ -70,7 +71,7 @@
                             </barButtonItem>
                             <barButtonItem systemItem="search" id="eWR-Gw-LV2">
                                 <connections>
-                                    <segue destination="3fm-DV-8DE" kind="push" animates="NO" id="b9L-31-Eo1"/>
+                                    <segue destination="3fm-DV-8DE" kind="push" id="b9L-31-Eo1"/>
                                 </connections>
                             </barButtonItem>
                         </rightBarButtonItems>
@@ -104,20 +105,33 @@
                                     <rect key="frame" x="0.0" y="0.0" width="287" height="59"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uCw-Eq-0ot">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uCw-Eq-0ot">
                                             <rect key="frame" x="8" y="8" width="43" height="43"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="43" id="z7N-Pk-UzP"/>
+                                            </constraints>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GnB-Sd-GfY">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GnB-Sd-GfY">
                                             <rect key="frame" x="59" y="19" width="228" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="uCw-Eq-0ot" firstAttribute="leading" secondItem="MhT-2s-DTM" secondAttribute="leadingMargin" id="7ra-6q-ZE0"/>
+                                        <constraint firstAttribute="trailing" secondItem="GnB-Sd-GfY" secondAttribute="trailing" id="WG5-FI-PJ6"/>
+                                        <constraint firstItem="GnB-Sd-GfY" firstAttribute="top" secondItem="MhT-2s-DTM" secondAttribute="topMargin" constant="11" id="ZYM-ZC-WCb"/>
+                                        <constraint firstItem="uCw-Eq-0ot" firstAttribute="top" secondItem="MhT-2s-DTM" secondAttribute="topMargin" id="agz-nZ-yIh"/>
+                                        <constraint firstItem="GnB-Sd-GfY" firstAttribute="leading" secondItem="uCw-Eq-0ot" secondAttribute="trailing" constant="8" symbolic="YES" id="e9z-RY-ERt"/>
+                                        <constraint firstItem="uCw-Eq-0ot" firstAttribute="centerY" secondItem="GnB-Sd-GfY" secondAttribute="centerY" id="fXc-ga-URa"/>
+                                        <constraint firstItem="uCw-Eq-0ot" firstAttribute="bottom" secondItem="MhT-2s-DTM" secondAttribute="bottomMargin" id="tcZ-qp-4My"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="imageViewUser" destination="uCw-Eq-0ot" id="GfN-Ja-Drz"/>
                                     <outlet property="labelUsername" destination="GnB-Sd-GfY" id="RuH-KL-BhK"/>
+                                    <segue destination="XpC-9Y-HS1" kind="push" identifier="segue.search.user.details" id="Veq-MN-hTl"/>
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="searchTagCell" id="FOQ-Ox-79B" customClass="IKSearchTagCell">
@@ -127,23 +141,36 @@
                                     <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Tag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lp4-Y1-X7o">
-                                            <rect key="frame" x="8" y="11" width="183" height="21"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lp4-Y1-X7o">
+                                            <rect key="frame" x="8" y="11" width="191" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fcx-Ik-Wos">
-                                            <rect key="frame" x="199" y="11" width="88" height="21"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fcx-Ik-Wos">
+                                            <rect key="frame" x="207" y="22" width="80" height="21"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="80" id="DVM-5U-nFm"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="fcx-Ik-Wos" secondAttribute="bottom" id="2nI-YG-Zw9"/>
+                                        <constraint firstItem="lp4-Y1-X7o" firstAttribute="centerY" secondItem="21o-7c-QuN" secondAttribute="centerY" id="9Bv-i3-992"/>
+                                        <constraint firstItem="lp4-Y1-X7o" firstAttribute="top" secondItem="21o-7c-QuN" secondAttribute="topMargin" constant="3" id="ByD-se-gtk"/>
+                                        <constraint firstAttribute="trailing" secondItem="fcx-Ik-Wos" secondAttribute="trailing" id="GSR-oP-jzh"/>
+                                        <constraint firstItem="lp4-Y1-X7o" firstAttribute="leading" secondItem="21o-7c-QuN" secondAttribute="leadingMargin" id="eI3-MK-3Jt"/>
+                                        <constraint firstItem="fcx-Ik-Wos" firstAttribute="top" secondItem="21o-7c-QuN" secondAttribute="topMargin" constant="14" id="mPC-6j-iN6"/>
+                                        <constraint firstItem="fcx-Ik-Wos" firstAttribute="leading" secondItem="lp4-Y1-X7o" secondAttribute="trailing" constant="8" symbolic="YES" id="uXJ-O4-j4L"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="labelMediaCount" destination="fcx-Ik-Wos" id="ZNZ-dk-wkZ"/>
                                     <outlet property="labelTag" destination="lp4-Y1-X7o" id="QHH-Zh-uFG"/>
+                                    <segue destination="XpC-9Y-HS1" kind="push" identifier="segue.search.tag.details" id="pdV-WQ-KQF"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -159,7 +186,66 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gby-HI-TVl" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="422" y="895"/>
+            <point key="canvasLocation" x="-12" y="857"/>
+        </scene>
+        <!--Search Collection View Controller-->
+        <scene sceneID="qkO-3a-XCV">
+            <objects>
+                <collectionViewController id="XpC-9Y-HS1" customClass="IKSearchCollectionViewController" sceneMemberID="viewController">
+                    <collectionView key="view" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" minimumZoomScale="0.0" maximumZoomScale="0.0" dataMode="prototypes" id="od7-V0-wcn">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="EkK-3G-2hC">
+                            <size key="itemSize" width="106" height="106"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="1" minY="0.0" maxX="1" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                        <cells>
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CPCELL" id="7Sx-vB-cGa" customClass="IKCollectionCell">
+                                <rect key="frame" x="1" y="64" width="106" height="106"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                    <rect key="frame" x="0.0" y="0.0" width="106" height="106"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="BMs-4a-tvx">
+                                            <rect key="frame" x="0.0" y="0.0" width="106" height="106"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </imageView>
+                                    </subviews>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                </view>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="BMs-4a-tvx" secondAttribute="bottom" id="FBo-cu-cF6"/>
+                                    <constraint firstAttribute="trailing" secondItem="BMs-4a-tvx" secondAttribute="trailing" id="IT8-K5-q1l"/>
+                                    <constraint firstItem="BMs-4a-tvx" firstAttribute="leading" secondItem="7Sx-vB-cGa" secondAttribute="leading" id="elC-IL-AUB"/>
+                                    <constraint firstItem="BMs-4a-tvx" firstAttribute="top" secondItem="7Sx-vB-cGa" secondAttribute="top" id="wk5-Bc-Ezi"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="imageView" destination="BMs-4a-tvx" id="Fb1-XZ-yPG"/>
+                                    <segue destination="05T-VM-ZrT" kind="push" identifier="segue.search.detail" id="BDP-G5-UNW"/>
+                                </connections>
+                            </collectionViewCell>
+                        </cells>
+                        <connections>
+                            <outlet property="dataSource" destination="XpC-9Y-HS1" id="ej8-ae-7PD"/>
+                            <outlet property="delegate" destination="XpC-9Y-HS1" id="tyf-6l-zs1"/>
+                        </connections>
+                    </collectionView>
+                    <navigationItem key="navigationItem" id="8wo-k5-uSZ">
+                        <barButtonItem key="rightBarButtonItem" enabled="NO" title="More" id="QCI-8V-stV">
+                            <connections>
+                                <action selector="moreTapped:" destination="XpC-9Y-HS1" id="vw8-Yk-IvE"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </collectionViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GYZ-w0-kOC" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="422" y="857"/>
         </scene>
         <!--Media View Controller-->
         <scene sceneID="i2X-FZ-KL9">
@@ -208,7 +294,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WTX-8B-147" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1025" y="104"/>
+            <point key="canvasLocation" x="919" y="104"/>
         </scene>
         <!--Login -->
         <scene sceneID="vux-rx-nxM">
@@ -241,14 +327,20 @@
                             <constraint firstItem="xL7-Gk-126" firstAttribute="top" secondItem="bBm-kX-gC1" secondAttribute="bottom" id="zDW-rM-vzb"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Login " id="tLF-sk-vbt"/>
+                    <navigationItem key="navigationItem" title="Login " id="tLF-sk-vbt">
+                        <barButtonItem key="leftBarButtonItem" systemItem="refresh" id="oNH-HI-g7Z">
+                            <connections>
+                                <action selector="refreshAuthorizationURL:" destination="Qfj-6N-R6z" id="MSo-JS-lSI"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="webView" destination="bBm-kX-gC1" id="jm6-gY-iFs"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aGH-ev-YqG" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1245" y="-565"/>
+            <point key="canvasLocation" x="422" y="-565"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="R63-K3-3iq">
@@ -266,11 +358,12 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ppB-8V-TCB" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="104"/>
+            <point key="canvasLocation" x="-85" y="104"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="9CP-FP-i2A">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="krw-cl-279" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController storyboardIdentifier="LoginNavigationViewController" automaticallyAdjustsScrollViewInsets="NO" id="Yqa-wS-RqO" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="xgb-Qe-nBg"/>
@@ -283,9 +376,12 @@
                         <segue destination="Qfj-6N-R6z" kind="relationship" relationship="rootViewController" id="6GZ-4R-J9G"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="krw-cl-279" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="851" y="-565"/>
+            <point key="canvasLocation" x="-85" y="-565"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="Veq-MN-hTl"/>
+        <segue reference="BDP-G5-UNW"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/InstagramKit-Example/InstagramKit-Example/Base.lproj/Main.storyboard
+++ b/InstagramKit-Example/InstagramKit-Example/Base.lproj/Main.storyboard
@@ -186,7 +186,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gby-HI-TVl" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-12" y="857"/>
+            <point key="canvasLocation" x="-85" y="857"/>
         </scene>
         <!--Search Collection View Controller-->
         <scene sceneID="qkO-3a-XCV">
@@ -363,7 +363,6 @@
         <!--Navigation Controller-->
         <scene sceneID="9CP-FP-i2A">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="krw-cl-279" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController storyboardIdentifier="LoginNavigationViewController" automaticallyAdjustsScrollViewInsets="NO" id="Yqa-wS-RqO" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="xgb-Qe-nBg"/>
@@ -376,6 +375,7 @@
                         <segue destination="Qfj-6N-R6z" kind="relationship" relationship="rootViewController" id="6GZ-4R-J9G"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="krw-cl-279" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-85" y="-565"/>
         </scene>

--- a/InstagramKit-Example/InstagramKit-Example/Classes/AppDelegate.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/AppDelegate.h
@@ -25,6 +25,4 @@
 
 @property (strong, nonatomic) UIWindow *window;
 
-
 @end
-

--- a/InstagramKit-Example/InstagramKit-Example/Classes/AppDelegate.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/AppDelegate.m
@@ -25,8 +25,8 @@
 
 @end
 
-@implementation AppDelegate
 
+@implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/CollectionView Cells/IKCollectionCell.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/CollectionView Cells/IKCollectionCell.h
@@ -18,37 +18,10 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKLoginViewController.h"
-#import "InstagramKit.h"
+#import <UIKit/UIKit.h>
 
-@interface IKLoginViewController () <UIWebViewDelegate>
+@interface IKCollectionCell : UICollectionViewCell
 
-@property (weak, nonatomic) IBOutlet UIWebView *webView;
-
-@end
-
-@implementation IKLoginViewController
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    self.webView.scrollView.bounces = NO;
-    
-    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopeBasic];
-    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
-
-}
-
-
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
-{
-    NSError *error;
-    if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
-    {
-        [self.navigationController dismissViewControllerAnimated:TRUE completion:nil];
-        
-    }
-    return YES;
-}
+- (void)setImageUrl:(NSURL *)imageURL;
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/CollectionView Cells/IKCollectionCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/CollectionView Cells/IKCollectionCell.m
@@ -23,9 +23,10 @@
 
 @interface IKCollectionCell ()
 
-@property (weak, nonatomic) IBOutlet UIImageView *imageView;
+@property (nonatomic, weak) IBOutlet UIImageView *imageView;
 
 @end
+
 
 @implementation IKCollectionCell
 

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/CollectionView Cells/IKCollectionCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/CollectionView Cells/IKCollectionCell.m
@@ -18,37 +18,26 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKLoginViewController.h"
-#import "InstagramKit.h"
+#import "IKCollectionCell.h"
+#import "UIImageView+AFNetworking.h"
 
-@interface IKLoginViewController () <UIWebViewDelegate>
+@interface IKCollectionCell ()
 
-@property (weak, nonatomic) IBOutlet UIWebView *webView;
+@property (weak, nonatomic) IBOutlet UIImageView *imageView;
 
 @end
 
-@implementation IKLoginViewController
+@implementation IKCollectionCell
 
-- (void)viewDidLoad
+- (void)setImageUrl:(NSURL *)imageURL
 {
-    [super viewDidLoad];
-    self.webView.scrollView.bounces = NO;
-    
-    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopeBasic];
-    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
-
+    [self.imageView setImageWithURL:imageURL];
 }
 
-
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+- (void)prepareForReuse
 {
-    NSError *error;
-    if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
-    {
-        [self.navigationController dismissViewControllerAnimated:TRUE completion:nil];
-        
-    }
-    return YES;
+    [super prepareForReuse];
+    [self.imageView setImage:nil];
 }
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKCollectionViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKCollectionViewController.h
@@ -22,6 +22,4 @@
 
 @interface IKCollectionViewController : UICollectionViewController
 
-- (IBAction)unwindSegue:(UIStoryboardSegue *)sender;
-
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKCollectionViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKCollectionViewController.h
@@ -22,6 +22,6 @@
 
 @interface IKCollectionViewController : UICollectionViewController
 
--(IBAction)unwindSegue:(UIStoryboardSegue *)sender;
+- (IBAction)unwindSegue:(UIStoryboardSegue *)sender;
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKLoginViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKLoginViewController.h
@@ -22,4 +22,6 @@
 
 @interface IKLoginViewController : UIViewController
 
+- (IBAction)refreshAuthorizationURL:(id)sender;
+
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKLoginViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKLoginViewController.m
@@ -23,7 +23,7 @@
 
 @interface IKLoginViewController () <UIWebViewDelegate>
 
-@property (weak, nonatomic) IBOutlet UIWebView *webView;
+@property (nonatomic, weak) IBOutlet UIWebView *webView;
 
 @end
 
@@ -37,6 +37,7 @@
     [self requestAuthorization];
 }
 
+
 - (void)requestAuthorization
 {
     NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopePublicContent];
@@ -44,31 +45,41 @@
 }
 
 
+#pragma mark - WebViewDelegate Methods -
+
+
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
 {
     NSError *error;
     if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
     {
+        // Automatically dismiss this webview
         [self dismissViewControllerAnimated:YES completion:nil];
+        return YES;
     }
     
     if (error)
     {
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"InstagramKit" message:error.localizedDescription delegate:nil cancelButtonTitle:@"Okay" otherButtonTitles:nil, nil];
         [alert show];
-        [[InstagramEngine sharedEngine] logout];
         [self requestAuthorization];
     }
+    
     return YES;
 }
 
 
 #pragma mark - IBAction Methods -
 
+
+/**
+ Method where we clean the HTTP Cookie and reload again the authorization URL.
+ @discussion Help when the user goes to 'Forgot password' or other links inside the webview.
+ */
 - (IBAction)refreshAuthorizationURL:(id)sender
 {
+    [[InstagramEngine sharedEngine] logout];
     [self requestAuthorization];
 }
-
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKLoginViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKLoginViewController.m
@@ -33,10 +33,14 @@
 {
     [super viewDidLoad];
     self.webView.scrollView.bounces = NO;
-    
-    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopeBasic];
-    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
 
+    [self requestAuthorization];
+}
+
+- (void)requestAuthorization
+{
+    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopePublicContent];
+    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
 }
 
 
@@ -45,10 +49,26 @@
     NSError *error;
     if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
     {
-        [self.navigationController dismissViewControllerAnimated:TRUE completion:nil];
-        
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
+    
+    if (error)
+    {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"InstagramKit" message:error.localizedDescription delegate:nil cancelButtonTitle:@"Okay" otherButtonTitles:nil, nil];
+        [alert show];
+        [[InstagramEngine sharedEngine] logout];
+        [self requestAuthorization];
     }
     return YES;
 }
+
+
+#pragma mark - IBAction Methods -
+
+- (IBAction)refreshAuthorizationURL:(id)sender
+{
+    [self requestAuthorization];
+}
+
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKMediaViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKMediaViewController.m
@@ -18,7 +18,6 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
 #import "IKMediaViewController.h"
 #import "UIImageView+AFNetworking.h"
 #import "InstagramKit.h"
@@ -40,6 +39,13 @@
 {
     [super viewDidLoad];
     [self populateViews];
+}
+
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewWillLayoutSubviews];
+    [self.captionLabel sizeToFit];
 }
 
 

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKMediaViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKMediaViewController.m
@@ -22,18 +22,16 @@
 #import "UIImageView+AFNetworking.h"
 #import "InstagramKit.h"
 
-
 @interface IKMediaViewController ()
 
-@property (weak, nonatomic) IBOutlet UIImageView *imageView;
-@property (weak, nonatomic) IBOutlet UILabel *captionLabel;
+@property (nonatomic, weak) IBOutlet UIImageView *imageView;
+@property (nonatomic, weak) IBOutlet UILabel *captionLabel;
 @property (nonatomic, strong) InstagramMedia *media;
 
 @end
 
 
 @implementation IKMediaViewController
-
 
 - (void)viewDidLoad
 {
@@ -56,7 +54,5 @@
     [self.imageView setImageWithURL:self.media.standardResolutionImageURL];
     [self.captionLabel setText:self.media.caption.text];
 }
-
-
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.h
@@ -28,5 +28,4 @@
 - (void)setInstagramUser:(InstagramUser *)user;
 - (void)setInstagramTag:(InstagramTag *)tag;
 
-
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.h
@@ -18,45 +18,15 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKMediaViewController.h"
-#import "UIImageView+AFNetworking.h"
-#import "InstagramKit.h"
+#import <UIKit/UIKit.h>
 
+@class InstagramUser;
+@class InstagramTag;
 
-@interface IKMediaViewController ()
+@interface IKSearchCollectionViewController : UICollectionViewController
 
-@property (weak, nonatomic) IBOutlet UIImageView *imageView;
-@property (weak, nonatomic) IBOutlet UILabel *captionLabel;
-@property (nonatomic, strong) InstagramMedia *media;
-
-@end
-
-
-@implementation IKMediaViewController
-
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    [self populateViews];
-}
-
-
-- (void)viewDidLayoutSubviews
-{
-    [super viewWillLayoutSubviews];
-    [self.captionLabel sizeToFit];
-}
-
-
-- (void)populateViews
-{
-    [self setTitle:[NSString stringWithFormat:@"@%@",self.media.user.username]];
-    [self.imageView setImageWithURL:self.media.thumbnailURL];
-    [self.imageView setImageWithURL:self.media.standardResolutionImageURL];
-    [self.captionLabel setText:self.media.caption.text];
-}
-
+- (void)setInstagramUser:(InstagramUser *)user;
+- (void)setInstagramTag:(InstagramTag *)tag;
 
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.m
@@ -1,0 +1,186 @@
+//
+//    Copyright (c) 2015 Shyam Bhat
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "IKSearchCollectionViewController.h"
+#import "InstagramKit.h"
+#import "IKCollectionCell.h"
+#import "InstagramMedia.h"
+#import "IKMediaViewController.h"
+
+#define kNumberOfCellsInARow 3
+#define kFetchItemsCount 15
+
+@interface IKSearchCollectionViewController ()
+
+@property (nonatomic, strong) NSMutableArray *mediaArray;
+@property (nonatomic, strong) InstagramPaginationInfo *currentPaginationInfo;
+@property (nonatomic, weak) InstagramEngine *instagramEngine;
+@property (nonatomic, strong) InstagramUser *user;
+@property (nonatomic, strong) InstagramTag *tag;
+
+@end
+
+
+@implementation IKSearchCollectionViewController
+
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.mediaArray = [[NSMutableArray alloc] init];
+    self.instagramEngine = [InstagramEngine sharedEngine];
+    [self updateCollectionViewLayout];
+    
+    [self loadMedia];
+}
+
+
+- (void)loadMedia
+{
+    self.currentPaginationInfo = nil;
+    
+    [self.navigationItem.rightBarButtonItem setEnabled: NO];
+    [self.mediaArray removeAllObjects];
+    [self.collectionView reloadData];
+    
+    if (self.user)
+    {
+        [self setTitle:[NSString stringWithFormat:@"@%@", self.user.username]];
+        [self requestUserMediaRecent];
+    }
+    else if (self.tag)
+    {
+        [self setTitle:[NSString stringWithFormat:@"#%@", self.tag.name]];
+        [self requestTagMediaRecent];
+    }
+}
+
+
+- (void)setInstagramUser:(InstagramUser *)user
+{
+    [self setUser:user];
+}
+
+
+- (void)setInstagramTag:(InstagramTag *)tag
+{
+    [self setTag:tag];
+}
+
+
+#pragma mark - API Requests -
+
+
+- (void)requestUserMediaRecent
+{
+    [self.instagramEngine getMediaForUser:self.user.Id
+                                    count:kFetchItemsCount
+                                    maxId:self.currentPaginationInfo.nextMaxId
+                              withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+                                  
+                                  self.currentPaginationInfo = paginationInfo;
+                                  [self.navigationItem.rightBarButtonItem setEnabled:(paginationInfo) ? YES : NO];
+                                  
+                                  if (media.count > 0) {
+                                      [self.mediaArray addObjectsFromArray:media];
+                                      [self.collectionView reloadData];
+                                      
+                                      [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.mediaArray.count - 1 inSection:0] atScrollPosition:UICollectionViewScrollPositionCenteredVertically animated:YES];
+                                  }
+                                  
+                              } failure:^(NSError *error, NSInteger statusCode) {
+                                  NSLog(@"Request User Media Recent Failed");
+                              }];
+}
+
+- (void)requestTagMediaRecent
+{
+    [self.instagramEngine getMediaWithTagName:self.tag.name
+                                        count:kFetchItemsCount
+                                        maxId:self.currentPaginationInfo.nextMaxId
+                                  withSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+                                      
+                                      self.currentPaginationInfo = paginationInfo;
+                                      [self.navigationItem.rightBarButtonItem setEnabled:(paginationInfo) ? YES : NO];
+                                      
+                                      if (media.count > 0) {
+                                          [self.mediaArray addObjectsFromArray:media];
+                                          [self.collectionView reloadData];
+                                          
+                                          [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.mediaArray.count - 1 inSection:0] atScrollPosition:UICollectionViewScrollPositionCenteredVertically animated:YES];
+                                      }
+                                  } failure:^(NSError *error, NSInteger statusCode) {
+                                      NSLog(@"Request Tag Media Recent Failed");
+                                  }];
+}
+
+
+- (IBAction)moreTapped:(id)sender {
+    if (self.user)
+    {
+        [self requestUserMediaRecent];
+    }
+    else if (self.tag)
+    {
+        [self requestTagMediaRecent];
+    }
+}
+
+
+#pragma mark - UIStoryboardSegue -
+
+
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
+{
+    if ([segue.identifier isEqualToString:@"segue.search.detail"]) {
+        IKMediaViewController *mediaViewController = (IKMediaViewController *)segue.destinationViewController;
+        NSIndexPath *selectedIndexPath = [self.collectionView indexPathsForSelectedItems][0];
+        InstagramMedia *media = self.mediaArray[selectedIndexPath.item];
+        [mediaViewController setMedia:media];
+    }
+}
+
+
+#pragma mark - UICollectionViewDataSource Methods -
+
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
+{
+    return self.mediaArray.count;
+}
+
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    IKCollectionCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"CPCELL" forIndexPath:indexPath];
+    InstagramMedia *media = self.mediaArray[indexPath.row];
+    [cell setImageUrl:media.thumbnailURL];
+    return cell;
+}
+
+
+- (void)updateCollectionViewLayout
+{
+    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
+    CGFloat size = floor((CGRectGetWidth(self.collectionView.bounds)-1) / kNumberOfCellsInARow);
+    layout.itemSize = CGSizeMake(size, size);
+}
+
+@end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.m
@@ -86,7 +86,9 @@
 
 #pragma mark - API Requests -
 
-
+/**
+ @discussion You can get an error if the user's media you are trying to get, are from a private user account.
+ */
 - (void)requestUserMediaRecent
 {
     [self.instagramEngine getMediaForUser:self.user.Id

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchCollectionViewController.m
@@ -24,8 +24,8 @@
 #import "InstagramMedia.h"
 #import "IKMediaViewController.h"
 
-#define kNumberOfCellsInARow 3
-#define kFetchItemsCount 15
+#define kNumberOfCellsInARow 4
+#define kFetchItemsCount 20
 
 @interface IKSearchCollectionViewController ()
 
@@ -39,7 +39,6 @@
 
 
 @implementation IKSearchCollectionViewController
-
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -109,6 +108,7 @@
                                   NSLog(@"Request User Media Recent Failed");
                               }];
 }
+
 
 - (void)requestTagMediaRecent
 {

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.h
@@ -18,37 +18,8 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKLoginViewController.h"
-#import "InstagramKit.h"
+#import <UIKit/UIKit.h>
 
-@interface IKLoginViewController () <UIWebViewDelegate>
-
-@property (weak, nonatomic) IBOutlet UIWebView *webView;
-
-@end
-
-@implementation IKLoginViewController
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    self.webView.scrollView.bounces = NO;
-    
-    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopeBasic];
-    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
-
-}
-
-
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
-{
-    NSError *error;
-    if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
-    {
-        [self.navigationController dismissViewControllerAnimated:TRUE completion:nil];
-        
-    }
-    return YES;
-}
+@interface IKSearchViewController : UITableViewController <UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate>
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.h
@@ -20,6 +20,6 @@
 
 #import <UIKit/UIKit.h>
 
-@interface IKSearchViewController : UITableViewController <UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate>
+@interface IKSearchViewController : UITableViewController
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.m
@@ -22,7 +22,11 @@
 #import "InstagramKit.h"
 #import "IKSearchTagCell.h"
 #import "IKSearchUserCell.h"
-#import "AFURLResponseSerialization.h"
+#import "IKSearchCollectionViewController.h"
+
+#define kSignUser '@'
+#define kSignHash '#'
+
 
 @interface IKSearchViewController ()
 
@@ -77,16 +81,16 @@
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
     if (self.searchBar.text.length > 0) {
-        char symbol = [self.searchBar.text characterAtIndex:0];
+        char sign = [self.searchBar.text characterAtIndex:0];
         NSString *searchString = [self.searchBar.text substringFromIndex:1];
         
-        if (symbol != '@' && symbol != '#') {
-            symbol = '@';
+        if (sign != kSignUser && sign != kSignHash) {
+            sign = kSignUser;
             searchString = self.searchBar.text;
-            [self.searchBar setText:[NSString stringWithFormat:@"%c%@", symbol, searchString]];
+            [self.searchBar setText:[NSString stringWithFormat:@"%c%@", sign, searchString]];
         }
         if (searchString.length > 0) {
-            (symbol == '@') ? [self requestSearchUsers:searchString] : [self requestSearchTags:searchString];
+            (sign == kSignUser) ? [self requestSearchUsers:searchString] : [self requestSearchTags:searchString];
         }
     } else {
         [self.elementArray removeAllObjects];
@@ -128,20 +132,34 @@
 }
 
 
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    
+    id objClass = self.elementArray[indexPath.row];
+    if ([objClass isKindOfClass:[InstagramUser class]]) {
+        return 60;
+    }
+    return 44;
 }
 
 
-/*
- #pragma mark - Navigation
- 
- // In a storyboard-based application, you will often want to do a little preparation before navigation
- - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
- // Get the new view controller using [segue destinationViewController].
- // Pass the selected object to the new view controller.
- }
- */
+#pragma mark - UIStoryboardSegue -
+
+
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
+{
+    if ([segue.identifier isEqualToString:@"segue.search.user.details"]) {
+        IKSearchCollectionViewController *searchCollectionViewController = (IKSearchCollectionViewController *)segue.destinationViewController;
+        NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
+        InstagramUser *user = self.elementArray[selectedIndexPath.item];
+        [searchCollectionViewController setInstagramUser:user];
+    }
+    if ([segue.identifier isEqualToString:@"segue.search.tag.details"]) {
+        IKSearchCollectionViewController *searchCollectionViewController = (IKSearchCollectionViewController *)segue.destinationViewController;
+        NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
+        InstagramTag *tag = self.elementArray[selectedIndexPath.item];
+        [searchCollectionViewController setInstagramTag:tag];
+    }
+}
+
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.m
@@ -1,0 +1,147 @@
+//
+//    Copyright (c) 2015 Shyam Bhat
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "IKSearchViewController.h"
+#import "InstagramKit.h"
+#import "IKSearchTagCell.h"
+#import "IKSearchUserCell.h"
+#import "AFURLResponseSerialization.h"
+
+@interface IKSearchViewController ()
+
+@property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
+@property (nonatomic, strong)   NSMutableArray *elementArray;
+
+@end
+
+@implementation IKSearchViewController
+
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.elementArray = [[NSMutableArray alloc] init];
+    
+    [self.searchBar becomeFirstResponder];
+}
+
+
+#pragma mark - API Requests -
+
+
+- (void)requestSearchTags:(NSString *)tag
+{
+    [[InstagramEngine sharedEngine] searchTagsWithName:tag
+                                           withSuccess:^(NSArray *tags, InstagramPaginationInfo *paginationInfo) {
+                                               [self.elementArray removeAllObjects];
+                                               [self.elementArray addObjectsFromArray:tags];
+                                               [self.tableView reloadData];
+                                           } failure:^(NSError *error, NSInteger statusCode) {
+                                               NSLog(@"Request Search Tags Failed");
+                                           }];
+}
+
+
+- (void)requestSearchUsers:(NSString *)user
+{
+    [[InstagramEngine sharedEngine] searchUsersWithString:user
+                                              withSuccess:^(NSArray *users, InstagramPaginationInfo *paginationInfo) {
+                                                  [self.elementArray removeAllObjects];
+                                                  [self.elementArray addObjectsFromArray:users];
+                                                  [self.tableView reloadData];
+                                              } failure:^(NSError *error, NSInteger statusCode) {
+                                                  NSLog(@"Request Search Users Failed");
+                                              }];
+}
+
+
+#pragma mark - UISearchBar Methods -
+
+
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
+{
+    if (self.searchBar.text.length > 0) {
+        char symbol = [self.searchBar.text characterAtIndex:0];
+        NSString *searchString = [self.searchBar.text substringFromIndex:1];
+        
+        if (symbol != '@' && symbol != '#') {
+            symbol = '@';
+            searchString = self.searchBar.text;
+            [self.searchBar setText:[NSString stringWithFormat:@"%c%@", symbol, searchString]];
+        }
+        if (searchString.length > 0) {
+            (symbol == '@') ? [self requestSearchUsers:searchString] : [self requestSearchTags:searchString];
+        }
+    } else {
+        [self.elementArray removeAllObjects];
+        [self.tableView reloadData];
+    }
+}
+
+
+#pragma mark - UITableView Methods -
+
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return self.elementArray.count;
+}
+
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    id objClass = self.elementArray[indexPath.row];
+    
+    if ([objClass isKindOfClass:[InstagramUser class]]) {
+        IKSearchUserCell *userCell = [tableView dequeueReusableCellWithIdentifier:@"searchUserCell" forIndexPath:indexPath];
+        InstagramUser *user = objClass;
+        [userCell setUsername:user.username];
+        [userCell setUserImageUrl:user.profilePictureURL];
+        return userCell;
+        
+    } else if ([objClass isKindOfClass:[InstagramTag class]]) {
+        IKSearchTagCell *tagCell = [tableView dequeueReusableCellWithIdentifier:@"searchTagCell" forIndexPath:indexPath];
+        InstagramTag *tag = objClass;
+        [tagCell setTagName:tag.name];
+        [tagCell setMediaCount:tag.mediaCount];
+        return tagCell;
+        
+    } else {
+        return nil;
+    }
+}
+
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    
+}
+
+
+/*
+ #pragma mark - Navigation
+ 
+ // In a storyboard-based application, you will often want to do a little preparation before navigation
+ - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+ // Get the new view controller using [segue destinationViewController].
+ // Pass the selected object to the new view controller.
+ }
+ */
+
+@end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/IKSearchViewController.m
@@ -27,18 +27,18 @@
 #define kSignUser '@'
 #define kSignHash '#'
 
+@interface IKSearchViewController () <UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate>
 
-@interface IKSearchViewController ()
-
-@property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
-@property (nonatomic, strong)   NSMutableArray *elementArray;
+@property (nonatomic, weak) IBOutlet UISearchBar *searchBar;
+@property (nonatomic, strong) NSMutableArray *elementArray;
 
 @end
 
+
 @implementation IKSearchViewController
 
-
-- (void)viewDidLoad {
+- (void)viewDidLoad
+{
     [super viewDidLoad];
     self.elementArray = [[NSMutableArray alloc] init];
     
@@ -56,6 +56,7 @@
                                                [self.elementArray removeAllObjects];
                                                [self.elementArray addObjectsFromArray:tags];
                                                [self.tableView reloadData];
+                                               
                                            } failure:^(NSError *error, NSInteger statusCode) {
                                                NSLog(@"Request Search Tags Failed");
                                            }];
@@ -69,6 +70,7 @@
                                                   [self.elementArray removeAllObjects];
                                                   [self.elementArray addObjectsFromArray:users];
                                                   [self.tableView reloadData];
+                                                  
                                               } failure:^(NSError *error, NSInteger statusCode) {
                                                   NSLog(@"Request Search Users Failed");
                                               }];
@@ -84,6 +86,7 @@
         char sign = [self.searchBar.text characterAtIndex:0];
         NSString *searchString = [self.searchBar.text substringFromIndex:1];
         
+        // If the user doesn't specify if he wants to search a user or a hash, we put one them by default.
         if (sign != kSignUser && sign != kSignHash) {
             sign = kSignUser;
             searchString = self.searchBar.text;
@@ -92,6 +95,7 @@
         if (searchString.length > 0) {
             (sign == kSignUser) ? [self requestSearchUsers:searchString] : [self requestSearchTags:searchString];
         }
+        
     } else {
         [self.elementArray removeAllObjects];
         [self.tableView reloadData];
@@ -126,9 +130,8 @@
         [tagCell setMediaCount:tag.mediaCount];
         return tagCell;
         
-    } else {
-        return nil;
     }
+    return nil;
 }
 
 
@@ -138,7 +141,7 @@
     if ([objClass isKindOfClass:[InstagramUser class]]) {
         return 60;
     }
-    return 44;
+    return tableView.rowHeight;
 }
 
 
@@ -160,6 +163,5 @@
         [searchCollectionViewController setInstagramTag:tag];
     }
 }
-
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.h
@@ -20,8 +20,9 @@
 
 #import <UIKit/UIKit.h>
 
-@interface IKCell : UICollectionViewCell
+@interface IKSearchTagCell : UITableViewCell
 
-- (void)setImageUrl:(NSURL *)imageURL;
+- (void)setTagName:(NSString *)tag;
+- (void)setMediaCount:(NSInteger)mediaCount;
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.m
@@ -37,7 +37,7 @@
 
 - (void)setMediaCount:(NSInteger)mediaCount
 {
-    [self.labelMediaCount setText:[NSString stringWithFormat:@"%ld", mediaCount]];
+    [self.labelMediaCount setText:[NSString stringWithFormat:@"%ld", (long)mediaCount]];
 }
 
 

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.m
@@ -18,37 +18,27 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKLoginViewController.h"
-#import "InstagramKit.h"
+#import "IKSearchTagCell.h"
 
-@interface IKLoginViewController () <UIWebViewDelegate>
+@interface IKSearchTagCell ()
 
-@property (weak, nonatomic) IBOutlet UIWebView *webView;
+@property (weak, nonatomic) IBOutlet UILabel *labelTag;
+@property (weak, nonatomic) IBOutlet UILabel *labelMediaCount;
 
 @end
 
-@implementation IKLoginViewController
+@implementation IKSearchTagCell
 
-- (void)viewDidLoad
+- (void)setTagName:(NSString *)tag
 {
-    [super viewDidLoad];
-    self.webView.scrollView.bounces = NO;
-    
-    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopeBasic];
-    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
-
+    [self.labelTag setText:tag];
 }
 
 
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+- (void)setMediaCount:(NSInteger)mediaCount
 {
-    NSError *error;
-    if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
-    {
-        [self.navigationController dismissViewControllerAnimated:TRUE completion:nil];
-        
-    }
-    return YES;
+    [self.labelMediaCount setText:[NSString stringWithFormat:@"%ld", mediaCount]];
 }
+
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchTagCell.m
@@ -22,10 +22,11 @@
 
 @interface IKSearchTagCell ()
 
-@property (weak, nonatomic) IBOutlet UILabel *labelTag;
-@property (weak, nonatomic) IBOutlet UILabel *labelMediaCount;
+@property (nonatomic, weak) IBOutlet UILabel *labelTag;
+@property (nonatomic, weak) IBOutlet UILabel *labelMediaCount;
 
 @end
+
 
 @implementation IKSearchTagCell
 
@@ -39,6 +40,5 @@
 {
     [self.labelMediaCount setText:[NSString stringWithFormat:@"%ld", (long)mediaCount]];
 }
-
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.h
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.h
@@ -18,37 +18,11 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKLoginViewController.h"
-#import "InstagramKit.h"
+#import <UIKit/UIKit.h>
 
-@interface IKLoginViewController () <UIWebViewDelegate>
+@interface IKSearchUserCell : UITableViewCell
 
-@property (weak, nonatomic) IBOutlet UIWebView *webView;
-
-@end
-
-@implementation IKLoginViewController
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    self.webView.scrollView.bounces = NO;
-    
-    NSURL *authURL = [[InstagramEngine sharedEngine] authorizationURLForScope:InstagramKitLoginScopeBasic];
-    [self.webView loadRequest:[NSURLRequest requestWithURL:authURL]];
-
-}
-
-
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
-{
-    NSError *error;
-    if ([[InstagramEngine sharedEngine] receivedValidAccessTokenFromURL:request.URL error:&error])
-    {
-        [self.navigationController dismissViewControllerAnimated:TRUE completion:nil];
-        
-    }
-    return YES;
-}
+- (void)setUsername:(NSString *)username;
+- (void)setUserImageUrl:(NSURL *)imageURL;
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.m
@@ -25,6 +25,7 @@
 
 @property (weak, nonatomic) IBOutlet UILabel *labelUsername;
 @property (weak, nonatomic) IBOutlet UIImageView *imageViewUser;
+@property (weak, nonatomic) IBOutlet UILabel *labelMediaCount;
 
 @end
 

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.m
@@ -18,26 +18,29 @@
 //    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "IKCell.h"
+#import "IKSearchUserCell.h"
 #import "UIImageView+AFNetworking.h"
 
-@interface IKCell ()
+@interface IKSearchUserCell ()
 
-@property (weak, nonatomic) IBOutlet UIImageView *imageView;
+@property (weak, nonatomic) IBOutlet UILabel *labelUsername;
+@property (weak, nonatomic) IBOutlet UIImageView *imageViewUser;
 
 @end
 
-@implementation IKCell
+@implementation IKSearchUserCell
 
-- (void)setImageUrl:(NSURL *)imageURL
+
+- (void)setUsername:(NSString *)username
 {
-    [self.imageView setImageWithURL:imageURL];
+    [self.labelUsername setText:username];
 }
 
-- (void)prepareForReuse
+
+- (void)setUserImageUrl:(NSURL *)imageURL
 {
-    [super prepareForReuse];
-    [self.imageView setImage:nil];
+    [self.imageViewUser setImageWithURL:imageURL];
 }
+
 
 @end

--- a/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.m
+++ b/InstagramKit-Example/InstagramKit-Example/Classes/View/SearchView Cells/IKSearchUserCell.m
@@ -23,14 +23,14 @@
 
 @interface IKSearchUserCell ()
 
-@property (weak, nonatomic) IBOutlet UILabel *labelUsername;
-@property (weak, nonatomic) IBOutlet UIImageView *imageViewUser;
-@property (weak, nonatomic) IBOutlet UILabel *labelMediaCount;
+@property (nonatomic, weak) IBOutlet UILabel *labelUsername;
+@property (nonatomic, weak) IBOutlet UIImageView *imageViewUser;
+@property (nonatomic, weak) IBOutlet UILabel *labelMediaCount;
 
 @end
 
-@implementation IKSearchUserCell
 
+@implementation IKSearchUserCell
 
 - (void)setUsername:(NSString *)username
 {
@@ -42,6 +42,5 @@
 {
     [self.imageViewUser setImageWithURL:imageURL];
 }
-
 
 @end

--- a/InstagramKit.podspec
+++ b/InstagramKit.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files  = 'InstagramKit', 'InstagramKit/**/*.{h,m}'
   s.exclude_files = 'InstagramKitDemo'
   s.requires_arc = true
-  s.dependency 'AFNetworking', '~>2.0'
+  s.dependency 'AFNetworking', '~>3.0'
   s.default_subspec = 'Exclude-UICKeyChainStore'
 
   s.subspec 'Exclude-UICKeyChainStore' do |exclude_uickeychainstore|

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -252,6 +252,7 @@
     NSString *percentageEscapedPath = [path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     [self.httpManager GET:percentageEscapedPath
                parameters:params
+                  progress:nil
                   success:^(NSURLSessionDataTask *task, id responseObject) {
                       if (!success) return;
                       NSDictionary *responseDictionary = (NSDictionary *)responseObject;
@@ -275,6 +276,7 @@
     NSString *percentageEscapedPath = [path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     [self.httpManager GET:percentageEscapedPath
                parameters:params
+                 progress:nil
                   success:^(NSURLSessionDataTask *task, id responseObject) {
                       if (!success) return;
                       NSDictionary *responseDictionary = (NSDictionary *)responseObject;
@@ -308,6 +310,7 @@
     NSDictionary *params = [self dictionaryWithAccessTokenAndParameters:parameters];
     [self.httpManager POST:path
                 parameters:params
+                  progress:nil
                    success:^(NSURLSessionDataTask *task, id responseObject) {
                        (success)? success((NSDictionary *)responseObject) : 0;
                    }

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,3 @@
 platform :ios, "7.0"
 
-pod 'AFNetworking', '~>2.0'
+pod 'AFNetworking', '~>3.0'

--- a/README.md
+++ b/README.md
@@ -166,23 +166,6 @@ Read in detail about more ways of implementing Pagination for your requests effo
 
 Download and run the Example Project to understand how the engine is intended to be used.
 
-##Changelog
-**Version 3.6.9**
-
-##### Added
-- Xcode 7 changes to Project file.
-- Added CHANGELOG.md
-
-##### Changed
-- `-getMediaAtLocation: count: maxId: withSuccess: failure:` changed to `-getMediaAtLocation: count: maxId: distance: withSuccess: failure:`
-- #167 Typo fixed `-authorizarionURL` to `authorizationURL`. By @natan.
-
-##### Fixed
-- #146 Checks for media URLs in initializing InstagramMedia objects.
-- #148 Fix Token Get in Authorisation scopes. By @DanTakagaki.
-- #165 Parameter Count must be larger than zero. Fixes #150. By @shyambhat
-- #164 InstagramModel copyWithZone updated to allocate correct type of object. By @urklc.
-
 ##Contributions?
 
 Glad you asked. Check out the [open Issues](https://github.com/shyambhat/InstagramKit/issues?state=open) and jump right in. Please submit pull requests to the `dev` branch.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It’s neat, fast and works like a charm.
 
 Getting started is easy. Just include the files from the directory 'InstagramKit' into your project and you'll be up and running. You may need to add AFNetworking to your project as well if you haven't already.
 
-####Cocoapods Podfile
+####CocoaPods Podfile
 ```ruby
 pod 'InstagramKit', '~> 3.0'
 ```


### PR DESCRIPTION
As we know:

> Apps created on or after Nov 17, 2015 will start in Sandbox Mode and function on newly updated API rate-limits and behaviors.
[...]
> Any app created before Nov 17, 2015 will continue to function until June 2016.

https://www.instagram.com/developer/

For this reason the InstagramKit-Example doesn't work for new Instagram apps clientID.
I updated the original example and adapted to the new behaviors. Now the user has to be authenticated to use the app. All the (new) endpoints require an accesstoken.

It's true that you can always generate your accesstoken and that way the user doesn't have to authenticate against Instagram, but be careful when a user has a private account or things like that. And also, all the 'self' API endpoints will be related to the accesstoken owner account.

Anyway, I also added some new functionalities like search by username or tag to show all the things you can do with this framework.

I make a PR of all this code to the dev branch.
Hope you like it!