### PR TITLE
Change to a non-deprecated API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Once you're authenticated and InstagramKit has been provided an `accessToken`, i
 
 ```Objective-C
 InstagramEngine *engine = [InstagramEngine sharedEngine];
-[engine getSelfFeedWithSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
+[engine getSelfRecentMediaWithSuccess:^(NSArray *media, InstagramPaginationInfo *paginationInfo) {
     // media is an array of InstagramMedia objects
     ...
 } failure:^(NSError *error, NSInteger statusCode) {


### PR DESCRIPTION
Changed the README.md to not use a deprecated endpoint, as they don't work for newly registered Instagram Applications using it. More about it here: #225
