### PR TITLE
Issue #239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 #### [Unreleased]
 **on `dev` branch**
 - [#221](https://github.com/shyambhat/InstagramKit/pull/221) Support for Instagram Platform updates.
+- [#239](https://github.com/shyambhat/InstagramKit/issues/239) Implemented issue. By [@afilipowicz](https://github.com/afilipowicz)
 
 ## [3.8] - 2016-03-20
 - [#201](https://github.com/shyambhat/InstagramKit/pull/201) Fixed issue [#194](https://github.com/shyambhat/InstagramKit/pull/194): New Permissions For Instagram. By [@zzdjk6](https://github.com/zzdjk6)

--- a/InstagramKit/Engine/InstagramEngine.m
+++ b/InstagramKit/Engine/InstagramEngine.m
@@ -285,7 +285,10 @@
                       success(modelObject);
                   }
                   failure:^(NSURLSessionDataTask *task, NSError *error) {
-                      (failure)? failure(error, ((NSHTTPURLResponse *)[task response]).statusCode) : 0;
+                      NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
+                      NSDictionary *serializedResponseData = [NSJSONSerialization JSONObjectWithData: errorData options:kNilOptions error:nil];
+                      
+                      (failure) ? failure(error,((NSHTTPURLResponse*)[task response]).statusCode, serializedResponseData) : 0;
                   }];
 }
 
@@ -320,8 +323,10 @@
                           });
                       });
                   }
-                  failure:^(NSURLSessionDataTask *task, NSError *error) {
-                      (failure)? failure(error, ((NSHTTPURLResponse *)[task response]).statusCode) : 0;
+                  failure:^(NSURLSessionDataTask *task, NSError *error) {                         NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
+                      NSDictionary *serializedResponseData = [NSJSONSerialization JSONObjectWithData: errorData options:kNilOptions error:nil];
+                      
+                      (failure) ? failure(error,((NSHTTPURLResponse*)[task response]).statusCode, serializedResponseData) : 0;
                   }];
 }
 
@@ -339,7 +344,10 @@
                        (success)? success((NSDictionary *)responseObject) : 0;
                    }
                    failure:^(NSURLSessionDataTask *task, NSError *error) {
-                       (failure) ? failure(error,((NSHTTPURLResponse*)[task response]).statusCode) : 0;
+                       NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
+                       NSDictionary *serializedResponseData = [NSJSONSerialization JSONObjectWithData: errorData options:kNilOptions error:nil];
+                       
+                       (failure) ? failure(error,((NSHTTPURLResponse*)[task response]).statusCode, serializedResponseData) : 0;
                    }];
 }
 
@@ -356,7 +364,10 @@
                          (success)? success((NSDictionary *)responseObject) : 0;
                      }
                      failure:^(NSURLSessionDataTask *task, NSError *error) {
-                         (failure) ? failure(error,((NSHTTPURLResponse*)[task response]).statusCode) : 0;
+                         NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
+                         NSDictionary *serializedResponseData = [NSJSONSerialization JSONObjectWithData: errorData options:kNilOptions error:nil];
+
+                         (failure) ? failure(error,((NSHTTPURLResponse*)[task response]).statusCode, serializedResponseData) : 0;
                      }];
 }
 

--- a/InstagramKit/InstagramKitConstants.h
+++ b/InstagramKit/InstagramKitConstants.h
@@ -229,8 +229,9 @@ typedef void (^InstagramLocationBlock)(InstagramLocation *location);
  *
  *  @param error
  *  @param serverStatusCode 
+ *  @param response
  */
-typedef void (^InstagramFailureBlock)(NSError* error, NSInteger serverStatusCode);
+typedef void (^InstagramFailureBlock)(NSError* error, NSInteger serverStatusCode, NSDictionary *response);
 
 /**
  *  A generic response block providing the server response dictionary, as is.

--- a/InstagramKitTests/InstagramEngineBaseTests.m
+++ b/InstagramKitTests/InstagramEngineBaseTests.m
@@ -126,7 +126,7 @@
                      XCTAssertTrue([object isKindOfClass:modelClass]);
                      [expectation fulfill];
                  }
-                 failure:^(NSError * _Nonnull error, NSInteger serverStatusCode) {
+                 failure:^(NSError * _Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                      XCTAssertNil(error);
                  }];
     
@@ -150,7 +150,7 @@
                      XCTAssertTrue([object isKindOfClass:modelClass]);
                      [expectation fulfill];
                  }
-                 failure:^(NSError * _Nonnull error, NSInteger serverStatusCode) {
+                 failure:^(NSError * _Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                      XCTAssertNil(error);
                  }];
     
@@ -174,7 +174,7 @@
                               XCTAssertTrue([paginatedObjects[0] isKindOfClass:modelClass]);
                               [expectation fulfill];
                           }
-                          failure:^(NSError * _Nonnull error, NSInteger serverStatusCode) {
+                          failure:^(NSError * _Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                               XCTAssertNil(error);
                  }];
     

--- a/InstagramKitTests/InstagramEngineMediaTests.m
+++ b/InstagramKitTests/InstagramEngineMediaTests.m
@@ -48,7 +48,7 @@
                                                XCTAssertTrue([media.Id isEqualToString:testMediaId]);
                                                [expectation fulfill];
                                            }
-                                           failure:^(NSError *_Nonnull error, NSInteger serverStatusCode) {
+                                           failure:^(NSError *_Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                                                XCTAssertNil(error);
                                            }];
     
@@ -78,7 +78,7 @@
                                                      [expectation fulfill];
 
                                                  }
-                                                 failure:^(NSError *_Nonnull error, NSInteger serverStatusCode) {
+                                                 failure:^(NSError *_Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                                                      XCTAssertNil(error);
                                                  }];
     
@@ -105,7 +105,7 @@
                                                        [expectation fulfill];
 
                                                    }
-                                                   failure:^(NSError *_Nonnull error, NSInteger serverStatusCode) {
+                                                   failure:^(NSError *_Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                                                        XCTAssertNil(error);
                                                    }];
     

--- a/InstagramKitTests/InstagramEngineUserTests.m
+++ b/InstagramKitTests/InstagramEngineUserTests.m
@@ -68,7 +68,7 @@
                                               [expectation fulfill];
 
                                           }
-                                          failure:^(NSError *_Nonnull error, NSInteger serverStatusCode) {
+                                          failure:^(NSError *_Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
                                               XCTAssertNil(error);
                                           }];
 
@@ -90,7 +90,7 @@
         
         [expectation fulfill];
 
-    } failure:^(NSError * _Nonnull error, NSInteger serverStatusCode) {
+    } failure:^(NSError * _Nonnull error, NSInteger serverStatusCode, NSDictionary *response) {
         XCTAssertNil(error);
     }];
     


### PR DESCRIPTION
https://github.com/shyambhat/InstagramKit/issues/239
Failure block should contain whole response if developers want to access it.
