### PR TITLE
Fixed crash for missing full_name in InstagramUser

### DIFF
--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -48,7 +48,7 @@
 - (void)updateDetailsWithInfo:(NSDictionary *)info
 {
     self.username = [[NSString alloc] initWithString:info[kUsername]];
-    self.fullName = (IKNotNull(info[kProfilePictureURL])) ? [[NSString alloc] initWithString:info[kFullName]] : nil;
+    self.fullName = (IKNotNull(info[kFullName])) ? [[NSString alloc] initWithString:info[kFullName]] : nil;
     
     self.profilePictureURL = (IKNotNull(info[kProfilePictureURL])) ? [[NSURL alloc] initWithString:info[kProfilePictureURL]] : nil;
     self.bio = (IKNotNull(info[kBio])) ? [[NSString alloc] initWithString:info[kBio]] : nil;

--- a/InstagramKit/Models/InstagramUser.m
+++ b/InstagramKit/Models/InstagramUser.m
@@ -48,7 +48,7 @@
 - (void)updateDetailsWithInfo:(NSDictionary *)info
 {
     self.username = [[NSString alloc] initWithString:info[kUsername]];
-    self.fullName = [[NSString alloc] initWithString:info[kFullName]];
+    self.fullName = (IKNotNull(info[kProfilePictureURL])) ? [[NSString alloc] initWithString:info[kFullName]] : nil;
     
     self.profilePictureURL = (IKNotNull(info[kProfilePictureURL])) ? [[NSURL alloc] initWithString:info[kProfilePictureURL]] : nil;
     self.bio = (IKNotNull(info[kBio])) ? [[NSString alloc] initWithString:info[kBio]] : nil;


### PR DESCRIPTION
Instagram seemed to have restricted access to certain properties and they have dropped the full_name in some cases. 
For instance when requesting: `GET /users/self/media/recent/` the users_in_photos property only has username and no full_name anymore.