### PR TITLE
Avoid crash when AFNetworkingOperationFailingURLResponseDataErrorKey is not present

### DIFF
--- a/InstagramKit/Classes/Engine/InstagramEngine.m
+++ b/InstagramKit/Classes/Engine/InstagramEngine.m
@@ -365,7 +365,11 @@
 - (NSDictionary *)serializedResponseDataFromError:(NSError *)error
 {
     NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
-    return [NSJSONSerialization JSONObjectWithData: errorData options:kNilOptions error:nil];
+    if (errorData != nil) {
+      return [NSJSONSerialization JSONObjectWithData: errorData options:kNilOptions error:nil];
+    } else {
+      return nil;
+    }
 }
 
 


### PR DESCRIPTION
It avoids a crash when serialization is forced when AFNetworkingOperationFailingURLResponseDataErrorKey is not present. 