### PR TITLE
change path Encoding URL from HostAllowedCharacterSet to PathAllowedCharacterSet

### DIFF
--- a/InstagramKit/Classes/Engine/InstagramEngine.m
+++ b/InstagramKit/Classes/Engine/InstagramEngine.m
@@ -275,7 +275,7 @@
         failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self dictionaryWithAccessTokenAndParameters:parameters];
-    NSString *percentageEscapedPath = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    NSString *percentageEscapedPath = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     [self.httpManager GET:percentageEscapedPath
                parameters:params
                  progress:nil
@@ -299,7 +299,7 @@
                  failure:(InstagramFailureBlock)failure
 {
     NSDictionary *params = [self dictionaryWithAccessTokenAndParameters:parameters];
-    NSString *percentageEscapedPath = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    NSString *percentageEscapedPath = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     [self.httpManager GET:percentageEscapedPath
                parameters:params
                  progress:nil


### PR DESCRIPTION
When login or retrieve pictures using InstagramKit, Instagram return error with status code 400. 

It is caused by '%2f' characters in url path, which is converted from '/' characters.

The conversion should use PathAllowedCharacterSet, but the current code is using HostAllowedCharacterSet instead.

Thank you.